### PR TITLE
Update the maven conf to build an OSGi bundle

### DIFF
--- a/jimfs/pom.xml
+++ b/jimfs/pom.xml
@@ -27,6 +27,8 @@
 
   <artifactId>jimfs</artifactId>
 
+  <packaging>bundle</packaging>
+
   <name>Jimfs</name>
 
   <description>
@@ -112,6 +114,20 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>com.google.jimfs.*</Export-Package>
+            <Include-Resource>
+              META-INF/services=target/classes/META-INF/services
+            </Include-Resource>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
           <artifactId>maven-gpg-plugin</artifactId>
           <version>1.4</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.4.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
It would help if the produced jar embeds OSGi metadata during the build process. It is really straightforward and does not interfere with anything. It only adds a few entries in the MANIFEST.MF file and lets users of OSGi deploy this project very easily.
