### PR TITLE
Add Turkish path normalization

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/Configuration.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Configuration.java
@@ -346,6 +346,7 @@ public final class Configuration {
             normalization = n;
             break;
           case CASE_FOLD_UNICODE:
+          case CASE_FOLD_TURKISH:
           case CASE_FOLD_ASCII:
             checkNormalizationNotSet(n, caseFold);
             caseFold = n;

--- a/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
@@ -17,6 +17,7 @@
 package com.google.common.jimfs;
 
 import static com.google.common.jimfs.PathNormalization.CASE_FOLD_ASCII;
+import static com.google.common.jimfs.PathNormalization.CASE_FOLD_TURKISH;
 import static com.google.common.jimfs.PathNormalization.CASE_FOLD_UNICODE;
 import static com.google.common.jimfs.PathNormalization.NFC;
 import static com.google.common.jimfs.PathNormalization.NFD;
@@ -334,5 +335,15 @@ public class ConfigurationTest {
       fail();
     } catch (IllegalArgumentException expected) {
     }
+  }
+
+  @Test
+  public void testTurkishNormalization() {
+    Configuration config =
+        Configuration.windows()
+            .toBuilder()
+            .setNameCanonicalNormalization(CASE_FOLD_TURKISH)
+            .build();
+    assertThat(config.nameCanonicalNormalization).containsExactly(CASE_FOLD_TURKISH);
   }
 }

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsTurkishCaseInsensitiveFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsTurkishCaseInsensitiveFileSystemTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.jimfs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.FileSystem;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests a Turkish case-insensitive filesystem using public Files APIs.
+ *
+ * @author Ben Hamilton
+ */
+@RunWith(JUnit4.class)
+public class JimfsTurkishCaseInsensitiveFileSystemTest extends AbstractJimfsIntegrationTest {
+
+  private static final Configuration TURKISH_CONFIGURATION =
+      Configuration.windows()
+          .toBuilder()
+          .setNameCanonicalNormalization(PathNormalization.CASE_FOLD_TURKISH)
+          .build();
+
+  @Override
+  protected FileSystem createFileSystem() {
+    return Jimfs.newFileSystem(TURKISH_CONFIGURATION);
+  }
+
+  @Test
+  public void caseInsensitiveTurkishMatching() throws IOException {
+    Files.createDirectory(path("Windows"));
+    assertThatPath("Windows").isSameFileAs("W\u0130NDOWS");
+    assertThatPath("Windows").isNotSameFileAs("WINDOWS");
+    Files.createFile(path("SYSTEM.INI"));
+    assertThatPath("SYSTEM.INI").isNotSameFileAs("system.ini");
+    assertThatPath("SYSTEM.INI").isSameFileAs("system.\u0131n\u0131");
+  }
+}


### PR DESCRIPTION
We use `jimfs` in the Buck project (https://github.com/facebook/buck/) for a number of our unit tests.

I was fixing some i18n bugs in Buck when I noticed there was no ability to create a filesystem using Turkish normalization rules. This pull request fixes the TODO in `PathNormalization` and adds a few tests.

I didn't handle regular expression matching yet, since there doesn't seem to be a way to create a Java regular expression using Turkish case-insensitive rules.

I also tidied up a `switch` statement in `Configuration` to raise a compiler error if anyone else adds a new enum value to `PathNormalization` (I was tripped up by this initially since we had a `default` case which raised a runtime error for new enum values).

Note: I work for Facebook, but we've already signed the Google corporate CLA. I got approval from our Open Source team to send in this pull request.