### PR TITLE
Throw UOE when setting unsupported attributes

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
@@ -264,7 +264,7 @@ final class AttributeService {
       }
     }
 
-    throw new IllegalArgumentException("cannot set attribute '" + view + ":" + attribute + "'");
+    throw new UnsupportedOperationException("cannot set attribute '" + view + ":" + attribute + "'");
   }
 
   /**

--- a/jimfs/src/test/java/com/google/common/jimfs/AttributeServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AttributeServiceTest.java
@@ -162,14 +162,14 @@ public class AttributeServiceTest {
     try {
       service.setAttribute(file, "test:blah", "blah", false);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (UnsupportedOperationException expected) {
     }
 
     try {
       // baz is defined by "test", but basic doesn't inherit test
       service.setAttribute(file, "basic:baz", 5, false);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (UnsupportedOperationException expected) {
     }
 
     assertThat(file.getAttribute("test", "baz")).isEqualTo(1);

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
@@ -684,7 +684,7 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
     try {
       Files.createFile(path("/foo"), new BasicFileAttribute<>("basic:noSuchAttribute", "foo"));
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (UnsupportedOperationException expected) {
     }
 
     assertThatPath("/foo").doesNotExist();


### PR DESCRIPTION
This commit modifies the behavior when setting unsupported attributes to
throw an `UnsupportedOperationException` instead of an
`IllegalArgumentException`. This is to make
`JimfsFileSystemProvider#createDirectory` and
`JimfsFileSystemProvider#newByteChannel` behave consistently with the
Javadocs for [`FileSystemProvider#createDirectory`](https://docs.oracle.com/javase/7/docs/api/java/nio/file/spi/FileSystemProvider.html#createDirectory(java.nio.file.Path,%20java.nio.file.attribute.FileAttribute...)) and
[`FileSystemProvider#newByteChannel`](https://docs.oracle.com/javase/7/docs/api/java/nio/file/spi/FileSystemProvider.html#newByteChannel(java.nio.file.Path,%20java.util.Set,%20java.nio.file.attribute.FileAttribute...)) which require an
`UnsupportedOperationException` to be thrown when the array of attributes
contains attributes which can not be set. In particular, these methods
are invoked via [`Files#createDirectory`](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createDirectory(java.nio.file.Path,%20java.nio.file.attribute.FileAttribute...)), [`Files#createTempDirectory`](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createTempDirectory(java.nio.file.Path,%20java.lang.String,%20java.nio.file.attribute.FileAttribute...)) and [`Files#createFile`](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createFile(java.nio.file.Path,%20java.nio.file.attribute.FileAttribute...)) which
have the same requirement regarding throwing an
`UnsupportedOperationException` when the array of attributes contains
attributes which can not be set. Most notably, this causes a discrepancy
between the handling of Jimfs when configured to act like a Windows
filesystem versus the behavior of `sun.nio.fs.WindowsFileSystem` where the
former will throw an `IllegalArgumentException` if an attempt is made to
set a POSIX attribute but the latter will throw an
`UnsupportedOperationException` (consistent with the Javadocs).