### PR TITLE
Add descriptive error message to .toFile()

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsPath.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsPath.java
@@ -408,7 +408,7 @@ final class JimfsPath implements Path {
   @Override
   public File toFile() {
     // documented as unsupported for anything but the default file system
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("You can not do .toFile() on a jimfs Path object");
   }
 
   @Override


### PR DESCRIPTION
I was a bit confused by only seeing the java.lang.UnsupportedOperationException without any further explanation. This error message would make it clear why the exception is thrown.