### PR TITLE
Fix the outdated link of google's java style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,5 @@ Please also ensure that the code compiles and that changes have appropriate
 tests.
 
 [1]: https://developers.google.com/open-source/cla/individual
-[2]: http://google-styleguide.googlecode.com/svn/trunk/javaguide.html
+[2]: https://google.github.io/styleguide/javaguide.html
 


### PR DESCRIPTION
Hi, 

In `CONTRIBUTING.md`, the link of Google Java style guide is outdated (given a `404` error code).
The current Java style guide is at
https://google.github.io/styleguide/javaguide.html

(used by the `google/guava` project
https://github.com/google/guava/blob/master/CONTRIBUTING.md)

This PR is a simple update for the link.
