### PR TITLE
Modifier 'private' is redundant for enum constructors.

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
@@ -79,8 +79,9 @@ final class AttributeService {
     for (AttributeProvider provider : providers) {
       byViewNameBuilder.put(provider.name(), provider);
       byViewTypeBuilder.put(provider.viewType(), provider);
-      if (provider.attributesType() != null) {
-        byAttributesTypeBuilder.put(provider.attributesType(), provider);
+        Class<? extends BasicFileAttributes> attributesType = provider.attributesType();
+        if (attributesType != null) {
+            byAttributesTypeBuilder.put(attributesType, provider);
       }
 
       for (Map.Entry<String, ?> entry : provider.defaultValues(userProvidedDefaults).entrySet()) {

--- a/jimfs/src/main/java/com/google/common/jimfs/FileFactory.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileFactory.java
@@ -79,7 +79,7 @@ final class FileFactory {
   /**
    * Creates and returns a copy of the given file.
    */
-  public File copyWithoutContent(File file) throws IOException {
+  public File copyWithoutContent(File file) {
     return file.copyWithoutContent(nextFileId());
   }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/Handler.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Handler.java
@@ -78,7 +78,7 @@ public final class Handler extends URLStreamHandler {
   public Handler() {} // a public, no-arg constructor is required
 
   @Override
-  protected URLConnection openConnection(URL url) throws IOException {
+  protected URLConnection openConnection(URL url) {
     return new PathURLConnection(url);
   }
 }

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 /**

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
@@ -63,7 +63,7 @@ final class JimfsFileChannel extends FileChannel {
    * channel is closed by another thread.
    */
   @GuardedBy("blockingThreads")
-  private final Set<Thread> blockingThreads = new HashSet<Thread>();
+  private final Set<Thread> blockingThreads = new HashSet<>();
 
   private final RegularFile file;
   private final FileSystemState fileSystemState;

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
@@ -592,7 +592,7 @@ final class JimfsFileChannel extends FileChannel {
   }
 
   @Override
-  public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+  public MappedByteBuffer map(MapMode mode, long position, long size) {
     // would like this to pretend to work, but can't create an implementation of MappedByteBuffer
     // well, a direct buffer could be cast to MappedByteBuffer, but it couldn't work in general
     throw new UnsupportedOperationException();
@@ -673,7 +673,7 @@ final class JimfsFileChannel extends FileChannel {
     }
 
     @Override
-    public void release() throws IOException {
+    public void release() {
       valid.set(false);
     }
   }

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
@@ -249,7 +249,7 @@ final class JimfsFileStore extends FileStore {
   }
 
   @Override
-  public long getTotalSpace() throws IOException {
+  public long getTotalSpace() {
     state.checkOpen();
     return disk.getTotalSpace();
   }
@@ -261,7 +261,7 @@ final class JimfsFileStore extends FileStore {
   }
 
   @Override
-  public long getUnallocatedSpace() throws IOException {
+  public long getUnallocatedSpace() {
     state.checkOpen();
     return disk.getUnallocatedSpace();
   }
@@ -285,7 +285,7 @@ final class JimfsFileStore extends FileStore {
   }
 
   @Override
-  public Object getAttribute(String attribute) throws IOException {
+  public Object getAttribute(String attribute) {
     throw new UnsupportedOperationException();
   }
 }

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystem.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystem.java
@@ -299,7 +299,7 @@ final class JimfsFileSystem extends FileSystem {
   }
 
   @Override
-  public WatchService newWatchService() throws IOException {
+  public WatchService newWatchService() {
     return watchServiceConfig.newWatchService(defaultView, pathService);
   }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystemProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystemProvider.java
@@ -86,7 +86,7 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
   }
 
   @Override
-  public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+  public FileSystem newFileSystem(URI uri, Map<String, ?> env) {
     throw new UnsupportedOperationException(
         "This method should not be called directly;"
             + "use an overload of Jimfs.newFileSystem() to create a FileSystem.");
@@ -100,7 +100,7 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
   }
 
   @Override
-  public FileSystem newFileSystem(Path path, Map<String, ?> env) throws IOException {
+  public FileSystem newFileSystem(Path path, Map<String, ?> env) {
     JimfsPath checkedPath = checkPath(path);
     checkNotNull(env);
 
@@ -320,7 +320,7 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
   }
 
   @Override
-  public FileStore getFileStore(Path path) throws IOException {
+  public FileStore getFileStore(Path path) {
     return getFileSystem(path).getFileStore();
   }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystems.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystems.java
@@ -103,9 +103,11 @@ final class JimfsFileSystems {
 
       Name rootName = path.root();
 
-      Directory rootDir = fileFactory.createRootDirectory(rootName);
-      attributeService.setInitialAttributes(rootDir);
-      roots.put(rootName, rootDir);
+      if (rootName != null) {
+        Directory rootDir = fileFactory.createRootDirectory(rootName);
+        attributeService.setInitialAttributes(rootDir);
+        roots.put(rootName, rootDir);
+      }
     }
 
     return new JimfsFileStore(

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystems.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystems.java
@@ -116,7 +116,7 @@ final class JimfsFileSystems {
    * Creates the default view of the file system using the given working directory.
    */
   private static FileSystemView createDefaultView(
-      Configuration config, JimfsFileStore fileStore, PathService pathService) throws IOException {
+      Configuration config, JimfsFileStore fileStore, PathService pathService) {
     JimfsPath workingDirPath = pathService.parsePath(config.workingDirectory);
 
     Directory dir = fileStore.getRoot(workingDirPath.root());

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystems.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystems.java
@@ -121,8 +121,14 @@ final class JimfsFileSystems {
       Configuration config, JimfsFileStore fileStore, PathService pathService) {
     JimfsPath workingDirPath = pathService.parsePath(config.workingDirectory);
 
-    Directory dir = fileStore.getRoot(workingDirPath.root());
-    if (dir == null) {
+      Directory dir = null;
+      Name root = workingDirPath.root();
+
+      if (root != null) {
+          dir = fileStore.getRoot(root);
+      }
+
+      if (dir == null) {
       throw new IllegalArgumentException("Invalid working dir path: " + workingDirPath);
     }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsInputStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsInputStream.java
@@ -144,7 +144,7 @@ final class JimfsInputStream extends InputStream {
   }
 
   @Override
-  public synchronized void close() throws IOException {
+  public synchronized void close() {
     if (isOpen()) {
       fileSystemState.unregister(this);
       file.closed();

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsOutputStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsOutputStream.java
@@ -102,7 +102,7 @@ final class JimfsOutputStream extends OutputStream {
   }
 
   @Override
-  public synchronized void close() throws IOException {
+  public synchronized void close() {
     if (isOpen()) {
       fileSystemState.unregister(this);
       file.closed();

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsSecureDirectoryStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsSecureDirectoryStream.java
@@ -122,7 +122,7 @@ final class JimfsSecureDirectoryStream implements SecureDirectoryStream<Path> {
   public static final Filter<Object> ALWAYS_TRUE_FILTER =
       new Filter<Object>() {
         @Override
-        public boolean accept(Object entry) throws IOException {
+        public boolean accept(Object entry) {
           return true;
         }
       };

--- a/jimfs/src/main/java/com/google/common/jimfs/PathNormalization.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathNormalization.java
@@ -107,7 +107,7 @@ public enum PathNormalization implements Function<String, String> {
 
   private final int patternFlags;
 
-  private PathNormalization(int patternFlags) {
+  PathNormalization(int patternFlags) {
     this.patternFlags = patternFlags;
   }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/SystemJimfsFileSystemProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/SystemJimfsFileSystemProvider.java
@@ -102,7 +102,7 @@ public final class SystemJimfsFileSystemProvider extends FileSystemProvider {
   }
 
   @Override
-  public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+  public FileSystem newFileSystem(URI uri, Map<String, ?> env) {
     checkArgument(
         uri.getScheme().equalsIgnoreCase(URI_SCHEME),
         "uri (%s) scheme must be '%s'",
@@ -206,53 +206,53 @@ public final class SystemJimfsFileSystemProvider extends FileSystemProvider {
 
   @Override
   public SeekableByteChannel newByteChannel(
-      Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+      Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public DirectoryStream<Path> newDirectoryStream(
-      Path dir, DirectoryStream.Filter<? super Path> filter) throws IOException {
+      Path dir, DirectoryStream.Filter<? super Path> filter) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void createDirectory(Path dir, FileAttribute<?>... attrs) throws IOException {
+  public void createDirectory(Path dir, FileAttribute<?>... attrs) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void delete(Path path) throws IOException {
+  public void delete(Path path) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void copy(Path source, Path target, CopyOption... options) throws IOException {
+  public void copy(Path source, Path target, CopyOption... options) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void move(Path source, Path target, CopyOption... options) throws IOException {
+  public void move(Path source, Path target, CopyOption... options) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public boolean isSameFile(Path path, Path path2) throws IOException {
+  public boolean isSameFile(Path path, Path path2) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public boolean isHidden(Path path) throws IOException {
+  public boolean isHidden(Path path) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public FileStore getFileStore(Path path) throws IOException {
+  public FileStore getFileStore(Path path) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void checkAccess(Path path, AccessMode... modes) throws IOException {
+  public void checkAccess(Path path, AccessMode... modes) {
     throw new UnsupportedOperationException();
   }
 
@@ -264,19 +264,17 @@ public final class SystemJimfsFileSystemProvider extends FileSystemProvider {
 
   @Override
   public <A extends BasicFileAttributes> A readAttributes(
-      Path path, Class<A> type, LinkOption... options) throws IOException {
+      Path path, Class<A> type, LinkOption... options) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options)
-      throws IOException {
+  public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void setAttribute(Path path, String attribute, Object value, LinkOption... options)
-      throws IOException {
+  public void setAttribute(Path path, String attribute, Object value, LinkOption... options) {
     throw new UnsupportedOperationException();
   }
 }


### PR DESCRIPTION
If no access modifier is specified for the constructor of an enum type, the constructor is private.