### PR TITLE
`Files.newOutputStream(path, CREATE, TRUNCATE_EXISTING)` does not truncate the existing file

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
@@ -308,6 +308,9 @@ final class FileSystemView {
       // assume file exists unless we're explicitly trying to create a new file
       RegularFile file = lookUpRegularFile(path, options);
       if (file != null) {
+        if (options.contains(TRUNCATE_EXISTING)) {
+          file.truncate(0);
+        }
         return file;
       }
     }

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
@@ -56,13 +56,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
@@ -1382,6 +1376,20 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
     try (Reader reader = Files.newBufferedReader(path("/test.txt"), UTF_8)) {
       assertEquals("hello world", CharStreams.toString(reader));
     }
+  }
+
+  @Test
+  public void testStreamsTruncating() throws IOException {
+    try(OutputStream os = Files.newOutputStream(path("/test"), CREATE_NEW);
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os))) {
+      bw.write("This is a very-very-very-very long line.");
+    }
+
+    try(OutputStream os = Files.newOutputStream(path("/test"), CREATE, TRUNCATE_EXISTING);
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os))) {
+      bw.write("This is a short line.");
+    }
+    assertThatPath("/test").containsLines("This is a short line.");
   }
 
   @Test


### PR DESCRIPTION
Hi there,

I've found a bug in this library.

When using the `Files..newOutputStream(path, CREATE, TRUNCATE_EXISTING)` method the existing files are not truncated (see the failing unit test in the first commit).

I'd be very happy if you could merge and release this fix, 'cause I have to use some workarounds at the moment.

Thanks,
Vilmos