### PR TITLE
Moe Sync

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/AbstractAttributeView.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AbstractAttributeView.java
@@ -34,9 +34,7 @@ abstract class AbstractAttributeView implements FileAttributeView {
     this.lookup = checkNotNull(lookup);
   }
 
-  /**
-   * Looks up the file to get or set attributes on.
-   */
+  /** Looks up the file to get or set attributes on. */
   protected final File lookupFile() throws IOException {
     return lookup.lookup();
   }

--- a/jimfs/src/main/java/com/google/common/jimfs/AbstractWatchService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AbstractWatchService.java
@@ -24,7 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.WatchEvent;
@@ -42,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import javax.annotation.Nullable;
 
 /**
@@ -71,26 +69,20 @@ abstract class AbstractWatchService implements WatchService {
     return new Key(this, watchable, eventTypes);
   }
 
-  /**
-   * Returns whether or not this watch service is open.
-   */
+  /** Returns whether or not this watch service is open. */
   @VisibleForTesting
   public boolean isOpen() {
     return open.get();
   }
 
-  /**
-   * Enqueues the given key if the watch service is open; does nothing otherwise.
-   */
+  /** Enqueues the given key if the watch service is open; does nothing otherwise. */
   final void enqueue(Key key) {
     if (isOpen()) {
       queue.add(key);
     }
   }
 
-  /**
-   * Called when the given key is cancelled. Does nothing by default.
-   */
+  /** Called when the given key is cancelled. Does nothing by default. */
   public void cancelled(Key key) {}
 
   @VisibleForTesting
@@ -118,9 +110,7 @@ abstract class AbstractWatchService implements WatchService {
     return check(queue.take());
   }
 
-  /**
-   * Returns the given key, throwing an exception if it's the poison.
-   */
+  /** Returns the given key, throwing an exception if it's the poison. */
   @Nullable
   private WatchKey check(@Nullable WatchKey key) {
     if (key == poison) {
@@ -131,9 +121,7 @@ abstract class AbstractWatchService implements WatchService {
     return key;
   }
 
-  /**
-   * Checks that the watch service is open, throwing {@link ClosedWatchServiceException} if not.
-   */
+  /** Checks that the watch service is open, throwing {@link ClosedWatchServiceException} if not. */
   protected final void checkOpen() {
     if (!open.get()) {
       throw new ClosedWatchServiceException();
@@ -148,9 +136,7 @@ abstract class AbstractWatchService implements WatchService {
     }
   }
 
-  /**
-   * A basic implementation of {@link WatchEvent}.
-   */
+  /** A basic implementation of {@link WatchEvent}. */
   static final class Event<T> implements WatchEvent<T> {
 
     private final Kind<T> kind;
@@ -207,9 +193,7 @@ abstract class AbstractWatchService implements WatchService {
     }
   }
 
-  /**
-   * Implementation of {@link WatchKey} for an {@link AbstractWatchService}.
-   */
+  /** Implementation of {@link WatchKey} for an {@link AbstractWatchService}. */
   static final class Key implements WatchKey {
 
     @VisibleForTesting static final int MAX_QUEUE_SIZE = 256;
@@ -237,17 +221,13 @@ abstract class AbstractWatchService implements WatchService {
       this.subscribedTypes = ImmutableSet.copyOf(subscribedTypes);
     }
 
-    /**
-     * Gets the current state of this key, State.READY or SIGNALLED.
-     */
+    /** Gets the current state of this key, State.READY or SIGNALLED. */
     @VisibleForTesting
     State state() {
       return state.get();
     }
 
-    /**
-     * Gets whether or not this key is subscribed to the given type of event.
-     */
+    /** Gets whether or not this key is subscribed to the given type of event. */
     public boolean subscribesTo(WatchEvent.Kind<?> eventType) {
       return subscribedTypes.contains(eventType);
     }

--- a/jimfs/src/main/java/com/google/common/jimfs/AclAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AclAttributeProvider.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclFileAttributeView;
@@ -30,7 +29,6 @@ import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -98,7 +96,8 @@ final class AclAttributeProvider extends AttributeProvider {
       if (!(obj instanceof AclEntry)) {
         throw new IllegalArgumentException(
             "invalid element for attribute 'acl:acl': should be List<AclEntry>, "
-                + "found element of type " + obj.getClass());
+                + "found element of type "
+                + obj.getClass());
       }
     }
 
@@ -116,9 +115,7 @@ final class AclAttributeProvider extends AttributeProvider {
     return new View(lookup, (FileOwnerAttributeView) inheritedViews.get("owner"));
   }
 
-  /**
-   * Implementation of {@link AclFileAttributeView}.
-   */
+  /** Implementation of {@link AclFileAttributeView}. */
   private static final class View extends AbstractAttributeView implements AclFileAttributeView {
 
     private final FileOwnerAttributeView ownerView;

--- a/jimfs/src/main/java/com/google/common/jimfs/AttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AttributeProvider.java
@@ -20,12 +20,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.util.Arrays;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -35,21 +33,15 @@ import javax.annotation.Nullable;
  */
 public abstract class AttributeProvider {
 
-  /**
-   * Returns the view name that's used to get attributes from this provider.
-   */
+  /** Returns the view name that's used to get attributes from this provider. */
   public abstract String name();
 
-  /**
-   * Returns the names of other providers that this provider inherits attributes from.
-   */
+  /** Returns the names of other providers that this provider inherits attributes from. */
   public ImmutableSet<String> inherits() {
     return ImmutableSet.of();
   }
 
-  /**
-   * Returns the type of the view interface that this provider supports.
-   */
+  /** Returns the type of the view interface that this provider supports. */
   public abstract Class<? extends FileAttributeView> viewType();
 
   /**
@@ -64,25 +56,21 @@ public abstract class AttributeProvider {
    * are attribute identifier strings (in "view:attribute" form) and the value for each is the
    * default value that should be set for that attribute when creating a new file.
    *
-   * <p>The given map should be in the same format and contains user-provided default values. If
-   * the user provided any default values for attributes handled by this provider, those values
-   * should be checked to ensure they are of the correct type. Additionally, if any changes to a
-   * user-provided attribute are necessary (for example, creating an immutable defensive copy),
-   * that should be done. The resulting values should be included in the result map along with
-   * default values for any attributes the user did not provide a value for.
+   * <p>The given map should be in the same format and contains user-provided default values. If the
+   * user provided any default values for attributes handled by this provider, those values should
+   * be checked to ensure they are of the correct type. Additionally, if any changes to a
+   * user-provided attribute are necessary (for example, creating an immutable defensive copy), that
+   * should be done. The resulting values should be included in the result map along with default
+   * values for any attributes the user did not provide a value for.
    */
   public ImmutableMap<String, ?> defaultValues(Map<String, ?> userDefaults) {
     return ImmutableMap.of();
   }
 
-  /**
-   * Returns the set of attributes that are always available from this provider.
-   */
+  /** Returns the set of attributes that are always available from this provider. */
   public abstract ImmutableSet<String> fixedAttributes();
 
-  /**
-   * Returns whether or not this provider supports the given attribute directly.
-   */
+  /** Returns whether or not this provider supports the given attribute directly. */
   public boolean supports(String attribute) {
     return fixedAttributes().contains(attribute);
   }
@@ -103,9 +91,9 @@ public abstract class AttributeProvider {
   public abstract Object get(File file, String attribute);
 
   /**
-   * Sets the value of the given attribute in the given file object. The {@code create}
-   * parameter indicates whether or not the value is being set upon creation of a new file via a
-   * user-provided {@code FileAttribute}.
+   * Sets the value of the given attribute in the given file object. The {@code create} parameter
+   * indicates whether or not the value is being set upon creation of a new file via a user-provided
+   * {@code FileAttribute}.
    *
    * @throws IllegalArgumentException if the given attribute is one supported by this provider but
    *     it is not allowed to be set by the user
@@ -137,9 +125,7 @@ public abstract class AttributeProvider {
 
   // exception helpers
 
-  /**
-   * Throws a runtime exception indicating that the given attribute cannot be set.
-   */
+  /** Throws a runtime exception indicating that the given attribute cannot be set. */
   protected static RuntimeException unsettable(String view, String attribute, boolean create) {
     // This matches the behavior of the real file system implementations: if the attempt to set the
     // attribute is being made during file creation, throw UOE even though the attribute is one
@@ -173,16 +159,21 @@ public abstract class AttributeProvider {
   }
 
   /**
-   * Throws an illegal argument exception indicating that the given value is not one of the
-   * expected types for the given attribute.
+   * Throws an illegal argument exception indicating that the given value is not one of the expected
+   * types for the given attribute.
    */
   protected static IllegalArgumentException invalidType(
       String view, String attribute, Object value, Class<?>... expectedTypes) {
     Object expected =
         expectedTypes.length == 1 ? expectedTypes[0] : "one of " + Arrays.toString(expectedTypes);
     throw new IllegalArgumentException(
-        "invalid type " + value.getClass()
-            + " for attribute '" + view + ":" + attribute
-            + "': expected " + expected);
+        "invalid type "
+            + value.getClass()
+            + " for attribute '"
+            + view
+            + ":"
+            + attribute
+            + "': expected "
+            + expected);
   }
 }

--- a/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
@@ -22,7 +22,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -37,7 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 
 /**
@@ -56,9 +54,7 @@ final class AttributeService {
 
   private final ImmutableList<FileAttribute<?>> defaultValues;
 
-  /**
-   * Creates a new attribute service using the given configuration.
-   */
+  /** Creates a new attribute service using the given configuration. */
   public AttributeService(Configuration configuration) {
     this(getProviders(configuration), configuration.defaultAttributeValues);
   }
@@ -145,23 +141,17 @@ final class AttributeService {
     }
   }
 
-  /**
-   * Implements {@link FileSystem#supportedFileAttributeViews()}.
-   */
+  /** Implements {@link FileSystem#supportedFileAttributeViews()}. */
   public ImmutableSet<String> supportedFileAttributeViews() {
     return providersByName.keySet();
   }
 
-  /**
-   * Implements {@link FileStore#supportsFileAttributeView(Class)}.
-   */
+  /** Implements {@link FileStore#supportsFileAttributeView(Class)}. */
   public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
     return providersByViewType.containsKey(type);
   }
 
-  /**
-   * Sets all initial attributes for the given file, including the given attributes if possible.
-   */
+  /** Sets all initial attributes for the given file, including the given attributes if possible. */
   public void setInitialAttributes(File file, FileAttribute<?>... attrs) {
     // default values should already be sanitized by their providers
     for (int i = 0; i < defaultValues.size(); i++) {
@@ -178,9 +168,7 @@ final class AttributeService {
     }
   }
 
-  /**
-   * Copies the attributes of the given file to the given copy file.
-   */
+  /** Copies the attributes of the given file to the given copy file. */
   public void copyAttributes(File file, File copy, AttributeCopyOption copyOption) {
     switch (copyOption) {
       case ALL:
@@ -195,8 +183,8 @@ final class AttributeService {
   }
 
   /**
-   * Gets the value of the given attribute for the given file. {@code attribute} must be of the
-   * form "view:attribute" or "attribute".
+   * Gets the value of the given attribute for the given file. {@code attribute} must be of the form
+   * "view:attribute" or "attribute".
    */
   public Object getAttribute(File file, String attribute) {
     String view = getViewName(attribute);
@@ -236,9 +224,7 @@ final class AttributeService {
     return value;
   }
 
-  /**
-   * Sets the value of the given attribute to the given value for the given file.
-   */
+  /** Sets the value of the given attribute to the given value for the given file. */
   public void setAttribute(File file, String attribute, Object value, boolean create) {
     String view = getViewName(attribute);
     String attr = getSingleAttribute(attribute);
@@ -269,8 +255,8 @@ final class AttributeService {
   }
 
   /**
-   * Returns an attribute view of the given type for the given file lookup callback, or
-   * {@code null} if the view type is not supported.
+   * Returns an attribute view of the given type for the given file lookup callback, or {@code null}
+   * if the view type is not supported.
    */
   @SuppressWarnings("unchecked")
   @Nullable
@@ -320,9 +306,7 @@ final class AttributeService {
     return provider.view(lookup, ImmutableMap.copyOf(inheritedViews));
   }
 
-  /**
-   * Implements {@link Files#readAttributes(Path, String, LinkOption...)}.
-   */
+  /** Implements {@link Files#readAttributes(Path, String, LinkOption...)}. */
   public ImmutableMap<String, Object> readAttributes(File file, String attributes) {
     String view = getViewName(attributes);
     List<String> attrs = getAttributeNames(attributes);
@@ -415,9 +399,7 @@ final class AttributeService {
     return attributeNames.get(0);
   }
 
-  /**
-   * Simple implementation of {@link FileAttribute}.
-   */
+  /** Simple implementation of {@link FileAttribute}. */
   private static final class SimpleFileAttribute<T> implements FileAttribute<T> {
 
     private final String name;

--- a/jimfs/src/main/java/com/google/common/jimfs/BasicAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/BasicAttributeProvider.java
@@ -18,19 +18,17 @@ package com.google.common.jimfs;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
-
 import javax.annotation.Nullable;
 
 /**
- * Attribute provider that provides attributes common to all file systems,
- * the {@link BasicFileAttributeView} ("basic" or no view prefix), and allows the reading of
- * {@link BasicFileAttributes}.
+ * Attribute provider that provides attributes common to all file systems, the {@link
+ * BasicFileAttributeView} ("basic" or no view prefix), and allows the reading of {@link
+ * BasicFileAttributes}.
  *
  * @author Colin Decker
  */
@@ -131,9 +129,7 @@ final class BasicAttributeProvider extends AttributeProvider {
     return new Attributes(file);
   }
 
-  /**
-   * Implementation of {@link BasicFileAttributeView}.
-   */
+  /** Implementation of {@link BasicFileAttributeView}. */
   private static final class View extends AbstractAttributeView implements BasicFileAttributeView {
 
     protected View(FileLookup lookup) {
@@ -172,9 +168,7 @@ final class BasicAttributeProvider extends AttributeProvider {
     }
   }
 
-  /**
-   * Implementation of {@link BasicFileAttributes}.
-   */
+  /** Implementation of {@link BasicFileAttributes}. */
   static class Attributes implements BasicFileAttributes {
 
     private final FileTime lastModifiedTime;

--- a/jimfs/src/main/java/com/google/common/jimfs/Configuration.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Configuration.java
@@ -48,26 +48,26 @@ import javax.annotation.Nullable;
 
 /**
  * Immutable configuration for an in-memory file system. A {@code Configuration} is passed to a
- * method in {@link Jimfs} such as {@link Jimfs#newFileSystem(Configuration)} to create a new
- * {@link FileSystem} instance.
+ * method in {@link Jimfs} such as {@link Jimfs#newFileSystem(Configuration)} to create a new {@link
+ * FileSystem} instance.
  *
  * @author Colin Decker
  */
 public final class Configuration {
 
   /**
-   * <p>Returns the default configuration for a UNIX-like file system. A file system created with
-   * this configuration:
+   * Returns the default configuration for a UNIX-like file system. A file system created with this
+   * configuration:
    *
    * <ul>
    *   <li>uses {@code /} as the path name separator (see {@link PathType#unix()} for more
-   *   information on the path format)</li>
-   *   <li>has root {@code /} and working directory {@code /work}</li>
-   *   <li>performs case-sensitive file lookup</li>
-   *   <li>supports only the {@linkplain BasicFileAttributeView basic} file attribute view, to
-   *   avoid overhead for unneeded attributes</li>
-   *   <li>supports hard links, symbolic links, {@link SecureDirectoryStream} and
-   *   {@link FileChannel}</li>
+   *       information on the path format)
+   *   <li>has root {@code /} and working directory {@code /work}
+   *   <li>performs case-sensitive file lookup
+   *   <li>supports only the {@linkplain BasicFileAttributeView basic} file attribute view, to avoid
+   *       overhead for unneeded attributes
+   *   <li>supports hard links, symbolic links, {@link SecureDirectoryStream} and {@link
+   *       FileChannel}
    * </ul>
    *
    * <p>To create a modified version of this configuration, such as to include the full set of UNIX
@@ -97,7 +97,7 @@ public final class Configuration {
   }
 
   /**
-   * <p>Returns the default configuration for a Mac OS X-like file system.
+   * Returns the default configuration for a Mac OS X-like file system.
    *
    * <p>The primary differences between this configuration and the default {@link #unix()}
    * configuration are that this configuration does Unicode normalization on the display and
@@ -107,18 +107,18 @@ public final class Configuration {
    *
    * <ul>
    *   <li>uses {@code /} as the path name separator (see {@link PathType#unix()} for more
-   *   information on the path format)</li>
-   *   <li>has root {@code /} and working directory {@code /work}</li>
-   *   <li>does Unicode normalization on paths, both for lookup and for {@code Path} objects</li>
-   *   <li>does case-insensitive (for ASCII characters only) lookup</li>
-   *   <li>supports only the {@linkplain BasicFileAttributeView basic} file attribute view, to
-   *   avoid overhead for unneeded attributes</li>
-   *   <li>supports hard links, symbolic links and {@link FileChannel}</li>
+   *       information on the path format)
+   *   <li>has root {@code /} and working directory {@code /work}
+   *   <li>does Unicode normalization on paths, both for lookup and for {@code Path} objects
+   *   <li>does case-insensitive (for ASCII characters only) lookup
+   *   <li>supports only the {@linkplain BasicFileAttributeView basic} file attribute view, to avoid
+   *       overhead for unneeded attributes
+   *   <li>supports hard links, symbolic links and {@link FileChannel}
    * </ul>
    *
    * <p>To create a modified version of this configuration, such as to include the full set of UNIX
-   * file attribute views or to use full Unicode case insensitivity,
-   * {@linkplain #toBuilder() create a builder}.
+   * file attribute views or to use full Unicode case insensitivity, {@linkplain #toBuilder() create
+   * a builder}.
    *
    * <p>Example:
    *
@@ -135,8 +135,7 @@ public final class Configuration {
 
   private static final class OsxHolder {
     private static final Configuration OS_X =
-        unix()
-            .toBuilder()
+        unix().toBuilder()
             .setDisplayName("OSX")
             .setNameDisplayNormalization(NFC) // matches JDK 1.7u40+ behavior
             .setNameCanonicalNormalization(NFD, CASE_FOLD_ASCII) // NFD is default in HFS+
@@ -145,24 +144,24 @@ public final class Configuration {
   }
 
   /**
-   * <p>Returns the default configuration for a Windows-like file system. A file system created
-   * with this configuration:
+   * Returns the default configuration for a Windows-like file system. A file system created with
+   * this configuration:
    *
    * <ul>
    *   <li>uses {@code \} as the path name separator and recognizes {@code /} as a separator when
-   *   parsing paths (see {@link PathType#windows()} for more information on path format)</li>
-   *   <li>has root {@code C:\} and working directory {@code C:\work}</li>
-   *   <li>performs case-insensitive (for ASCII characters only) file lookup</li>
+   *       parsing paths (see {@link PathType#windows()} for more information on path format)
+   *   <li>has root {@code C:\} and working directory {@code C:\work}
+   *   <li>performs case-insensitive (for ASCII characters only) file lookup
    *   <li>creates {@code Path} objects that use case-insensitive (for ASCII characters only)
-   *   equality</li>
-   *   <li>supports only the {@linkplain BasicFileAttributeView basic} file attribute view, to
-   *   avoid overhead for unneeded attributes</li>
-   *   <li>supports hard links, symbolic links and {@link FileChannel}</li>
+   *       equality
+   *   <li>supports only the {@linkplain BasicFileAttributeView basic} file attribute view, to avoid
+   *       overhead for unneeded attributes
+   *   <li>supports hard links, symbolic links and {@link FileChannel}
    * </ul>
    *
    * <p>To create a modified version of this configuration, such as to include the full set of
-   * Windows file attribute views or to use full Unicode case insensitivity,
-   * {@linkplain #toBuilder() create a builder}.
+   * Windows file attribute views or to use full Unicode case insensitivity, {@linkplain
+   * #toBuilder() create a builder}.
    *
    * <p>Example:
    *
@@ -197,8 +196,8 @@ public final class Configuration {
    * returned; if the operating system is Mac OS X, {@link Configuration#osX()} is returned;
    * otherwise, {@link Configuration#unix()} is returned.
    *
-   * <p>This is the configuration used by the {@code Jimfs.newFileSystem} methods that do not take
-   * a {@code Configuration} parameter.
+   * <p>This is the configuration used by the {@code Jimfs.newFileSystem} methods that do not take a
+   * {@code Configuration} parameter.
    *
    * @since 1.1
    */
@@ -214,9 +213,7 @@ public final class Configuration {
     }
   }
 
-  /**
-   * Creates a new mutable {@link Configuration} builder using the given path type.
-   */
+  /** Creates a new mutable {@link Configuration} builder using the given path type. */
   public static Builder builder(PathType pathType) {
     return new Builder(pathType);
   }
@@ -246,9 +243,7 @@ public final class Configuration {
   final ImmutableSet<Feature> supportedFeatures;
   private final String displayName;
 
-  /**
-   * Creates an immutable configuration object from the given builder.
-   */
+  /** Creates an immutable configuration object from the given builder. */
   private Configuration(Builder builder) {
     this.pathType = builder.pathType;
     this.nameDisplayNormalization = builder.nameDisplayNormalization;
@@ -319,9 +314,7 @@ public final class Configuration {
     return new Builder(this);
   }
 
-  /**
-   * Mutable builder for {@link Configuration} objects.
-   */
+  /** Mutable builder for {@link Configuration} objects. */
   public static final class Builder {
 
     /** 8 KB. */
@@ -475,13 +468,13 @@ public final class Configuration {
      * Sets the maximum size (in bytes) for the file system's in-memory file storage. This maximum
      * size determines the maximum number of blocks that can be allocated to regular files, so it
      * should generally be a multiple of the {@linkplain #setBlockSize(int) block size}. The actual
-     * maximum size will be the nearest multiple of the block size that is less than or equal to
-     * the given size.
+     * maximum size will be the nearest multiple of the block size that is less than or equal to the
+     * given size.
      *
      * <p><b>Note:</b> The in-memory file storage will not be eagerly initialized to this size, so
      * it won't use more memory than is needed for the files you create. Also note that in addition
-     * to this limit, you will of course be limited by the amount of heap space available to the
-     * JVM and the amount of heap used by other objects, both in the file system and elsewhere.
+     * to this limit, you will of course be limited by the amount of heap space available to the JVM
+     * and the amount of heap used by other objects, both in the file system and elsewhere.
      *
      * <p>The default is 4 GB.
      */
@@ -493,13 +486,13 @@ public final class Configuration {
 
     /**
      * Sets the maximum amount of unused space (in bytes) in the file system's in-memory file
-     * storage that should be cached for reuse. By default, this will be equal to the
-     * {@linkplain #setMaxSize(long) maximum size} of the storage, meaning that all space that is
-     * freed when files are truncated or deleted is cached for reuse. This helps to avoid lots of
-     * garbage collection when creating and deleting many files quickly. This can be set to 0 to
-     * disable caching entirely (all freed blocks become available for garbage collection) or to
-     * some other number to put an upper bound on the maximum amount of unused space the file
-     * system will keep around.
+     * storage that should be cached for reuse. By default, this will be equal to the {@linkplain
+     * #setMaxSize(long) maximum size} of the storage, meaning that all space that is freed when
+     * files are truncated or deleted is cached for reuse. This helps to avoid lots of garbage
+     * collection when creating and deleting many files quickly. This can be set to 0 to disable
+     * caching entirely (all freed blocks become available for garbage collection) or to some other
+     * number to put an upper bound on the maximum amount of unused space the file system will keep
+     * around.
      *
      * <p>Like the maximum size, the actual value will be the closest multiple of the block size
      * that is less than or equal to the given size.
@@ -565,9 +558,7 @@ public final class Configuration {
       return this;
     }
 
-    /**
-     * Adds an attribute provider for a custom view for the file system to support.
-     */
+    /** Adds an attribute provider for a custom view for the file system to support. */
     public Builder addAttributeProvider(AttributeProvider provider) {
       checkNotNull(provider);
       if (attributeProviders == null) {
@@ -579,8 +570,8 @@ public final class Configuration {
 
     /**
      * Sets the default value to use for the given file attribute when creating new files. The
-     * attribute must be in the form "view:attribute". The value must be of a type that the
-     * provider for the view accepts.
+     * attribute must be in the form "view:attribute". The value must be of a type that the provider
+     * for the view accepts.
      *
      * <p>For the included attribute views, default values can be set for the following attributes:
      *
@@ -643,10 +634,10 @@ public final class Configuration {
     /**
      * Sets the roots for the file system.
      *
-     * @throws InvalidPathException if any of the given roots is not a valid path for this
-     *     builder's path type
-     * @throws IllegalArgumentException if any of the given roots is a valid path for this
-     *     builder's path type but is not a root path with no name elements
+     * @throws InvalidPathException if any of the given roots is not a valid path for this builder's
+     *     path type
+     * @throws IllegalArgumentException if any of the given roots is a valid path for this builder's
+     *     path type but is not a root path with no name elements
      */
     public Builder setRoots(String first, String... more) {
       List<String> roots = Lists.asList(first, more);
@@ -659,8 +650,8 @@ public final class Configuration {
     }
 
     /**
-     * Sets the path to the working directory for the file system. The working directory must be
-     * an absolute path starting with one of the configured roots.
+     * Sets the path to the working directory for the file system. The working directory must be an
+     * absolute path starting with one of the configured roots.
      *
      * @throws InvalidPathException if the given path is not valid for this builder's path type
      * @throws IllegalArgumentException if the given path is valid for this builder's path type but
@@ -686,8 +677,8 @@ public final class Configuration {
     }
 
     /**
-     * Sets the configuration that {@link WatchService} instances created by the file system
-     * should use. The default configuration polls watched directories for changes every 5 seconds.
+     * Sets the configuration that {@link WatchService} instances created by the file system should
+     * use. The default configuration polls watched directories for changes every 5 seconds.
      *
      * @since 1.1
      */
@@ -701,9 +692,7 @@ public final class Configuration {
       return this;
     }
 
-    /**
-     * Creates a new immutable configuration object from this builder.
-     */
+    /** Creates a new immutable configuration object from this builder. */
     public Configuration build() {
       return new Configuration(this);
     }

--- a/jimfs/src/main/java/com/google/common/jimfs/Directory.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Directory.java
@@ -19,9 +19,7 @@ package com.google.common.jimfs;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableSortedSet;
-
 import java.util.Iterator;
-
 import javax.annotation.Nullable;
 
 /**
@@ -34,16 +32,12 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
   /** The entry linking to this directory in its parent directory. */
   private DirectoryEntry entryInParent;
 
-  /**
-   * Creates a new normal directory with the given ID.
-   */
+  /** Creates a new normal directory with the given ID. */
   public static Directory create(int id) {
     return new Directory(id);
   }
 
-  /**
-   * Creates a new root directory with the given ID and name.
-   */
+  /** Creates a new root directory with the given ID and name. */
   public static Directory createRoot(int id, Name name) {
     return new Directory(id, name);
   }
@@ -97,24 +91,18 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
     parent().decrementLinkCount();
   }
 
-  /**
-   * Returns the number of entries in this directory.
-   */
+  /** Returns the number of entries in this directory. */
   @VisibleForTesting
   int entryCount() {
     return entryCount;
   }
 
-  /**
-   * Returns true if this directory has no entries other than those to itself and its parent.
-   */
+  /** Returns true if this directory has no entries other than those to itself and its parent. */
   public boolean isEmpty() {
     return entryCount() == 2;
   }
 
-  /**
-   * Returns the entry for the given name in this table or null if no such entry exists.
-   */
+  /** Returns the entry for the given name in this table or null if no such entry exists. */
   @Nullable
   public DirectoryEntry get(Name name) {
     int index = bucketIndex(name, table.length);
@@ -133,8 +121,8 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
   /**
    * Links the given name to the given file in this directory.
    *
-   * @throws IllegalArgumentException if {@code name} is a reserved name such as "." or if an
-   *     entry already exists for the name
+   * @throws IllegalArgumentException if {@code name} is a reserved name such as "." or if an entry
+   *     already exists for the name
    */
   public void link(Name name, File file) {
     DirectoryEntry entry = new DirectoryEntry(this, checkNotReserved(name, "link"), file);
@@ -170,9 +158,7 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
     return builder.build();
   }
 
-  /**
-   * Checks that the given name is not "." or "..". Those names cannot be set/removed by users.
-   */
+  /** Checks that the given name is not "." or "..". Those names cannot be set/removed by users. */
   private static Name checkNotReserved(Name name, String action) {
     if (isReserved(name)) {
       throw new IllegalArgumentException("cannot " + action + ": " + name);
@@ -180,9 +166,7 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
     return name;
   }
 
-  /**
-   * Returns true if the given name is "." or "..".
-   */
+  /** Returns true if the given name is "." or "..". */
   private static boolean isReserved(Name name) {
     // all "." and ".." names are canonicalized to the same objects, so we can use identity
     return name == Name.SELF || name == Name.PARENT;
@@ -199,9 +183,7 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
 
   private int entryCount;
 
-  /**
-   * Returns the index of the bucket in the array where an entry for the given name should go.
-   */
+  /** Returns the index of the bucket in the array where an entry for the given name should go. */
   private static int bucketIndex(Name name, int tableLength) {
     return name.hashCode() & (tableLength - 1);
   }
@@ -218,8 +200,8 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
   }
 
   /**
-   * Adds the given entry to the directory, overwriting an existing entry with the same name if
-   * such an entry exists.
+   * Adds the given entry to the directory, overwriting an existing entry with the same name if such
+   * an entry exists.
    */
   private void forcePut(DirectoryEntry entry) {
     put(entry, true);

--- a/jimfs/src/main/java/com/google/common/jimfs/DirectoryEntry.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/DirectoryEntry.java
@@ -20,14 +20,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.MoreObjects;
-
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.NotLinkException;
 import java.nio.file.Path;
 import java.util.Objects;
-
 import javax.annotation.Nullable;
 
 /**
@@ -52,9 +50,7 @@ final class DirectoryEntry {
     this.file = file;
   }
 
-  /**
-   * Returns {@code true} if and only if this entry represents an existing file.
-   */
+  /** Returns {@code true} if and only if this entry represents an existing file. */
   public boolean exists() {
     return file != null;
   }
@@ -118,16 +114,12 @@ final class DirectoryEntry {
     return this;
   }
 
-  /**
-   * Returns the directory containing this entry.
-   */
+  /** Returns the directory containing this entry. */
   public Directory directory() {
     return directory;
   }
 
-  /**
-   * Returns the name of this entry.
-   */
+  /** Returns the name of this entry. */
   public Name name() {
     return name;
   }
@@ -142,9 +134,7 @@ final class DirectoryEntry {
     return file;
   }
 
-  /**
-   * Returns the file this entry links to or {@code null} if the file does not exist
-   */
+  /** Returns the file this entry links to or {@code null} if the file does not exist */
   @Nullable
   public File fileOrNull() {
     return file;

--- a/jimfs/src/main/java/com/google/common/jimfs/DosAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/DosAttributeProvider.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.DosFileAttributeView;
@@ -28,7 +27,6 @@ import java.nio.file.attribute.DosFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -116,9 +114,7 @@ final class DosAttributeProvider extends AttributeProvider {
     return new Attributes(file);
   }
 
-  /**
-   * Implementation of {@link DosFileAttributeView}.
-   */
+  /** Implementation of {@link DosFileAttributeView}. */
   private static final class View extends AbstractAttributeView implements DosFileAttributeView {
 
     private final BasicFileAttributeView basicView;
@@ -165,9 +161,7 @@ final class DosAttributeProvider extends AttributeProvider {
     }
   }
 
-  /**
-   * Implementation of {@link DosFileAttributes}.
-   */
+  /** Implementation of {@link DosFileAttributes}. */
   static class Attributes extends BasicAttributeProvider.Attributes implements DosFileAttributes {
 
     private final boolean readOnly;

--- a/jimfs/src/main/java/com/google/common/jimfs/DowngradedDirectoryStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/DowngradedDirectoryStream.java
@@ -25,8 +25,8 @@ import java.nio.file.SecureDirectoryStream;
 import java.util.Iterator;
 
 /**
- * A thin wrapper around a {@link SecureDirectoryStream} that exists only to implement
- * {@link DirectoryStream} and NOT implement {@link SecureDirectoryStream}.
+ * A thin wrapper around a {@link SecureDirectoryStream} that exists only to implement {@link
+ * DirectoryStream} and NOT implement {@link SecureDirectoryStream}.
  *
  * @author Colin Decker
  */

--- a/jimfs/src/main/java/com/google/common/jimfs/DowngradedSeekableByteChannel.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/DowngradedSeekableByteChannel.java
@@ -24,8 +24,8 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 
 /**
- * A thin wrapper around a {@link FileChannel} that exists only to implement
- * {@link SeekableByteChannel} but NOT extend {@link FileChannel}.
+ * A thin wrapper around a {@link FileChannel} that exists only to implement {@link
+ * SeekableByteChannel} but NOT extend {@link FileChannel}.
  *
  * @author Colin Decker
  */

--- a/jimfs/src/main/java/com/google/common/jimfs/Feature.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Feature.java
@@ -42,11 +42,11 @@ public enum Feature {
    * <p>Affected method:
    *
    * <ul>
-   *   <li>{@link Files#createLink(Path, Path)}</li>
+   *   <li>{@link Files#createLink(Path, Path)}
    * </ul>
    *
-   * <p>If this feature is not enabled, this method will throw
-   * {@link UnsupportedOperationException}.
+   * <p>If this feature is not enabled, this method will throw {@link
+   * UnsupportedOperationException}.
    */
   LINKS,
 
@@ -56,12 +56,12 @@ public enum Feature {
    * <p>Affected methods:
    *
    * <ul>
-   *   <li>{@link Files#createSymbolicLink(Path, Path, FileAttribute...)}</li>
-   *   <li>{@link Files#readSymbolicLink(Path)}</li>
+   *   <li>{@link Files#createSymbolicLink(Path, Path, FileAttribute...)}
+   *   <li>{@link Files#readSymbolicLink(Path)}
    * </ul>
    *
-   * <p>If this feature is not enabled, these methods will throw
-   * {@link UnsupportedOperationException}.
+   * <p>If this feature is not enabled, these methods will throw {@link
+   * UnsupportedOperationException}.
    */
   SYMBOLIC_LINKS,
 
@@ -71,9 +71,9 @@ public enum Feature {
    * <p>Affected methods:
    *
    * <ul>
-   *   <li>{@link Files#newDirectoryStream(Path)}</li>
-   *   <li>{@link Files#newDirectoryStream(Path, DirectoryStream.Filter)}</li>
-   *   <li>{@link Files#newDirectoryStream(Path, String)}</li>
+   *   <li>{@link Files#newDirectoryStream(Path)}
+   *   <li>{@link Files#newDirectoryStream(Path, DirectoryStream.Filter)}
+   *   <li>{@link Files#newDirectoryStream(Path, String)}
    * </ul>
    *
    * <p>If this feature is enabled, the {@link DirectoryStream} instances returned by these methods
@@ -87,18 +87,18 @@ public enum Feature {
    * <p>Affected methods:
    *
    * <ul>
-   *   <li>{@link Files#newByteChannel(Path, OpenOption...)}</li>
-   *   <li>{@link Files#newByteChannel(Path, Set, FileAttribute...)}</li>
-   *   <li>{@link FileChannel#open(Path, OpenOption...)}</li>
-   *   <li>{@link FileChannel#open(Path, Set, FileAttribute...)}</li>
-   *   <li>{@link AsynchronousFileChannel#open(Path, OpenOption...)}</li>
-   *   <li>{@link AsynchronousFileChannel#open(Path, Set, ExecutorService, FileAttribute...)}</li>
+   *   <li>{@link Files#newByteChannel(Path, OpenOption...)}
+   *   <li>{@link Files#newByteChannel(Path, Set, FileAttribute...)}
+   *   <li>{@link FileChannel#open(Path, OpenOption...)}
+   *   <li>{@link FileChannel#open(Path, Set, FileAttribute...)}
+   *   <li>{@link AsynchronousFileChannel#open(Path, OpenOption...)}
+   *   <li>{@link AsynchronousFileChannel#open(Path, Set, ExecutorService, FileAttribute...)}
    * </ul>
    *
    * <p>If this feature is not enabled, the {@link SeekableByteChannel} instances returned by the
-   * {@code Files} methods will not be {@code FileChannel} instances and the
-   * {@code FileChannel.open} and {@code AsynchronousFileChannel.open} methods will throw
-   * {@link UnsupportedOperationException}.
+   * {@code Files} methods will not be {@code FileChannel} instances and the {@code
+   * FileChannel.open} and {@code AsynchronousFileChannel.open} methods will throw {@link
+   * UnsupportedOperationException}.
    */
   // TODO(cgdecker): Should support for AsynchronousFileChannel be a separate feature?
   FILE_CHANNEL

--- a/jimfs/src/main/java/com/google/common/jimfs/File.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/File.java
@@ -54,9 +54,7 @@ public abstract class File {
     this.lastModifiedTime = now;
   }
 
-  /**
-   * Returns the ID of this file.
-   */
+  /** Returns the ID of this file. */
   public int id() {
     return id;
   }
@@ -69,23 +67,17 @@ public abstract class File {
     return 0;
   }
 
-  /**
-   * Returns whether or not this file is a directory.
-   */
+  /** Returns whether or not this file is a directory. */
   public final boolean isDirectory() {
     return this instanceof Directory;
   }
 
-  /**
-   * Returns whether or not this file is a regular file.
-   */
+  /** Returns whether or not this file is a regular file. */
   public final boolean isRegularFile() {
     return this instanceof RegularFile;
   }
 
-  /**
-   * Returns whether or not this file is a symbolic link.
-   */
+  /** Returns whether or not this file is a symbolic link. */
   public final boolean isSymbolicLink() {
     return this instanceof SymbolicLink;
   }
@@ -98,8 +90,8 @@ public abstract class File {
   abstract File copyWithoutContent(int id);
 
   /**
-   * Copies the content of this file to the given file. The given file must be the same type of
-   * file as this file and should have no content.
+   * Copies the content of this file to the given file. The given file must be the same type of file
+   * as this file and should have no content.
    *
    * <p>This method is used for copying the content of a file after copying the file itself. Does
    * nothing by default.
@@ -115,9 +107,7 @@ public abstract class File {
     return null;
   }
 
-  /**
-   * Called when a stream or channel to this file is opened.
-   */
+  /** Called when a stream or channel to this file is opened. */
   void opened() {}
 
   /**
@@ -127,23 +117,19 @@ public abstract class File {
   void closed() {}
 
   /**
-   * Called when (a single link to) this file is deleted. There may be links remaining. Does
-   * nothing by default.
+   * Called when (a single link to) this file is deleted. There may be links remaining. Does nothing
+   * by default.
    */
   void deleted() {}
 
-  /**
-   * Returns whether or not this file is a root directory of the file system.
-   */
+  /** Returns whether or not this file is a root directory of the file system. */
   final boolean isRootDirectory() {
     // only root directories have their parent link pointing to themselves
     return isDirectory() && equals(((Directory) this).parent());
   }
 
-  /**
-   * Returns the current count of links to this file.
-   */
-  public synchronized final int links() {
+  /** Returns the current count of links to this file. */
+  public final synchronized int links() {
     return links;
   }
 
@@ -155,74 +141,58 @@ public abstract class File {
     checkNotNull(entry);
   }
 
-  /**
-   * Called when this file has been unlinked from a directory, either for a move or delete.
-   */
+  /** Called when this file has been unlinked from a directory, either for a move or delete. */
   void unlinked() {}
 
-  /**
-   * Increments the link count for this file.
-   */
-  synchronized final void incrementLinkCount() {
+  /** Increments the link count for this file. */
+  final synchronized void incrementLinkCount() {
     links++;
   }
 
-  /**
-   * Decrements the link count for this file.
-   */
-  synchronized final void decrementLinkCount() {
+  /** Decrements the link count for this file. */
+  final synchronized void decrementLinkCount() {
     links--;
   }
 
   /** Gets the creation time of the file. */
   @SuppressWarnings("GoodTime") // should return a java.time.Instant
-  public synchronized final long getCreationTime() {
+  public final synchronized long getCreationTime() {
     return creationTime;
   }
 
   /** Gets the last access time of the file. */
   @SuppressWarnings("GoodTime") // should return a java.time.Instant
-  public synchronized final long getLastAccessTime() {
+  public final synchronized long getLastAccessTime() {
     return lastAccessTime;
   }
 
   /** Gets the last modified time of the file. */
   @SuppressWarnings("GoodTime") // should return a java.time.Instant
-  public synchronized final long getLastModifiedTime() {
+  public final synchronized long getLastModifiedTime() {
     return lastModifiedTime;
   }
 
-  /**
-   * Sets the creation time of the file.
-   */
-  synchronized final void setCreationTime(long creationTime) {
+  /** Sets the creation time of the file. */
+  final synchronized void setCreationTime(long creationTime) {
     this.creationTime = creationTime;
   }
 
-  /**
-   * Sets the last access time of the file.
-   */
-  synchronized final void setLastAccessTime(long lastAccessTime) {
+  /** Sets the last access time of the file. */
+  final synchronized void setLastAccessTime(long lastAccessTime) {
     this.lastAccessTime = lastAccessTime;
   }
 
-  /**
-   * Sets the last modified time of the file.
-   */
-  synchronized final void setLastModifiedTime(long lastModifiedTime) {
+  /** Sets the last modified time of the file. */
+  final synchronized void setLastModifiedTime(long lastModifiedTime) {
     this.lastModifiedTime = lastModifiedTime;
   }
 
-  /**
-   * Sets the last access time of the file to the current time.
-   */
+  /** Sets the last access time of the file to the current time. */
   final void updateAccessTime() {
     setLastAccessTime(System.currentTimeMillis());
   }
 
-  /**
-   * Sets the last modified time of the file to the current time.
-   */
+  /** Sets the last modified time of the file to the current time. */
   final void updateModifiedTime() {
     setLastModifiedTime(System.currentTimeMillis());
   }
@@ -231,18 +201,16 @@ public abstract class File {
    * Returns the names of the attributes contained in the given attribute view in the file's
    * attributes table.
    */
-  public synchronized final ImmutableSet<String> getAttributeNames(String view) {
+  public final synchronized ImmutableSet<String> getAttributeNames(String view) {
     if (attributes == null) {
       return ImmutableSet.of();
     }
     return ImmutableSet.copyOf(attributes.row(view).keySet());
   }
 
-  /**
-   * Returns the attribute keys contained in the attributes map for the file.
-   */
+  /** Returns the attribute keys contained in the attributes map for the file. */
   @VisibleForTesting
-  synchronized final ImmutableSet<String> getAttributeKeys() {
+  final synchronized ImmutableSet<String> getAttributeKeys() {
     if (attributes == null) {
       return ImmutableSet.of();
     }
@@ -254,40 +222,32 @@ public abstract class File {
     return builder.build();
   }
 
-  /**
-   * Gets the value of the given attribute in the given view.
-   */
+  /** Gets the value of the given attribute in the given view. */
   @Nullable
-  public synchronized final Object getAttribute(String view, String attribute) {
+  public final synchronized Object getAttribute(String view, String attribute) {
     if (attributes == null) {
       return null;
     }
     return attributes.get(view, attribute);
   }
 
-  /**
-   * Sets the given attribute in the given view to the given value.
-   */
-  public synchronized final void setAttribute(String view, String attribute, Object value) {
+  /** Sets the given attribute in the given view to the given value. */
+  public final synchronized void setAttribute(String view, String attribute, Object value) {
     if (attributes == null) {
       attributes = HashBasedTable.create();
     }
     attributes.put(view, attribute, value);
   }
 
-  /**
-   * Deletes the given attribute from the given view.
-   */
-  public synchronized final void deleteAttribute(String view, String attribute) {
+  /** Deletes the given attribute from the given view. */
+  public final synchronized void deleteAttribute(String view, String attribute) {
     if (attributes != null) {
       attributes.remove(view, attribute);
     }
   }
 
-  /**
-   * Copies basic attributes (file times) from this file to the given file.
-   */
-  synchronized final void copyBasicAttributes(File target) {
+  /** Copies basic attributes (file times) from this file to the given file. */
+  final synchronized void copyBasicAttributes(File target) {
     target.setFileTimes(creationTime, lastModifiedTime, lastAccessTime);
   }
 
@@ -298,10 +258,8 @@ public abstract class File {
     this.lastAccessTime = lastAccessTime;
   }
 
-  /**
-   * Copies the attributes from this file to the given file.
-   */
-  synchronized final void copyAttributes(File target) {
+  /** Copies the attributes from this file to the given file. */
+  final synchronized void copyAttributes(File target) {
     copyBasicAttributes(target);
     target.putAll(attributes);
   }
@@ -317,8 +275,6 @@ public abstract class File {
 
   @Override
   public final String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("id", id())
-        .toString();
+    return MoreObjects.toStringHelper(this).add("id", id()).toString();
   }
 }

--- a/jimfs/src/main/java/com/google/common/jimfs/FileFactory.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileFactory.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
-
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -35,9 +34,7 @@ final class FileFactory {
 
   private final HeapDisk disk;
 
-  /**
-   * Creates a new file factory using the given disk for regular files.
-   */
+  /** Creates a new file factory using the given disk for regular files. */
   public FileFactory(HeapDisk disk) {
     this.disk = checkNotNull(disk);
   }
@@ -46,39 +43,29 @@ final class FileFactory {
     return idGenerator.getAndIncrement();
   }
 
-  /**
-   * Creates a new directory.
-   */
+  /** Creates a new directory. */
   public Directory createDirectory() {
     return Directory.create(nextFileId());
   }
 
-  /**
-   * Creates a new root directory with the given name.
-   */
+  /** Creates a new root directory with the given name. */
   public Directory createRootDirectory(Name name) {
     return Directory.createRoot(nextFileId(), name);
   }
 
-  /**
-   * Creates a new regular file.
-   */
+  /** Creates a new regular file. */
   @VisibleForTesting
   RegularFile createRegularFile() {
     return RegularFile.create(nextFileId(), disk);
   }
 
-  /**
-   * Creates a new symbolic link referencing the given target path.
-   */
+  /** Creates a new symbolic link referencing the given target path. */
   @VisibleForTesting
   SymbolicLink createSymbolicLink(JimfsPath target) {
     return SymbolicLink.create(nextFileId(), target);
   }
 
-  /**
-   * Creates and returns a copy of the given file.
-   */
+  /** Creates and returns a copy of the given file. */
   public File copyWithoutContent(File file) throws IOException {
     return file.copyWithoutContent(nextFileId());
   }
@@ -89,23 +76,17 @@ final class FileFactory {
 
   private final Supplier<RegularFile> regularFileSupplier = new RegularFileSupplier();
 
-  /**
-   * Returns a supplier that creates directories.
-   */
+  /** Returns a supplier that creates directories. */
   public Supplier<Directory> directoryCreator() {
     return directorySupplier;
   }
 
-  /**
-   * Returns a supplier that creates regular files.
-   */
+  /** Returns a supplier that creates regular files. */
   public Supplier<RegularFile> regularFileCreator() {
     return regularFileSupplier;
   }
 
-  /**
-   * Returns a supplier that creates a symbolic links to the given path.
-   */
+  /** Returns a supplier that creates a symbolic links to the given path. */
   public Supplier<SymbolicLink> symbolicLinkCreator(JimfsPath target) {
     return new SymbolicLinkSupplier(target);
   }

--- a/jimfs/src/main/java/com/google/common/jimfs/FileSystemState.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileSystemState.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.ClosedFileSystemException;
@@ -29,9 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Object that manages the open/closed state of a file system, ensuring that all open resources
- * are closed when the file system is closed and that file system methods throw an exception when
- * the file system has been closed.
+ * Object that manages the open/closed state of a file system, ensuring that all open resources are
+ * closed when the file system is closed and that file system methods throw an exception when the
+ * file system has been closed.
  *
  * @author Colin Decker
  */
@@ -49,9 +48,7 @@ final class FileSystemState implements Closeable {
     this.onClose = checkNotNull(onClose);
   }
 
-  /**
-   * Returns whether or not the file system is open.
-   */
+  /** Returns whether or not the file system is open. */
   public boolean isOpen() {
     return open.get();
   }
@@ -66,8 +63,8 @@ final class FileSystemState implements Closeable {
   }
 
   /**
-   * Registers the given resource to be closed when the file system is closed. Should be called
-   * when the resource is opened.
+   * Registers the given resource to be closed when the file system is closed. Should be called when
+   * the resource is opened.
    */
   public <C extends Closeable> C register(C resource) {
     // Initial open check to avoid incrementing registering if we already know it's closed.
@@ -88,9 +85,7 @@ final class FileSystemState implements Closeable {
     }
   }
 
-  /**
-   * Unregisters the given resource. Should be called when the resource is closed.
-   */
+  /** Unregisters the given resource. Should be called when the resource is closed. */
   public void unregister(Closeable resource) {
     resources.remove(resource);
   }

--- a/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
@@ -28,7 +28,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
-
 import java.io.IOException;
 import java.nio.file.CopyOption;
 import java.nio.file.DirectoryNotEmptyException;
@@ -49,7 +48,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
-
 import javax.annotation.Nullable;
 
 /**
@@ -70,9 +68,7 @@ final class FileSystemView {
   private final Directory workingDirectory;
   private final JimfsPath workingDirectoryPath;
 
-  /**
-   * Creates a new file system view.
-   */
+  /** Creates a new file system view. */
   public FileSystemView(
       JimfsFileStore store, Directory workingDirectory, JimfsPath workingDirectoryPath) {
     this.store = checkNotNull(store);
@@ -80,16 +76,12 @@ final class FileSystemView {
     this.workingDirectoryPath = checkNotNull(workingDirectoryPath);
   }
 
-  /**
-   * Returns whether or not this view and the given view belong to the same file system.
-   */
+  /** Returns whether or not this view and the given view belong to the same file system. */
   private boolean isSameFileSystem(FileSystemView other) {
     return store == other.store;
   }
 
-  /**
-   * Returns the file system state.
-   */
+  /** Returns the file system state. */
   public FileSystemState state() {
     return store.state();
   }
@@ -102,9 +94,7 @@ final class FileSystemView {
     return workingDirectoryPath;
   }
 
-  /**
-   * Attempt to look up the file at the given path.
-   */
+  /** Attempt to look up the file at the given path. */
   DirectoryEntry lookUpWithLock(JimfsPath path, Set<? super LinkOption> options)
       throws IOException {
     store.readLock().lock();
@@ -115,18 +105,16 @@ final class FileSystemView {
     }
   }
 
-  /**
-   * Looks up the file at the given path without locking.
-   */
+  /** Looks up the file at the given path without locking. */
   private DirectoryEntry lookUp(JimfsPath path, Set<? super LinkOption> options)
       throws IOException {
     return store.lookUp(workingDirectory, path, options);
   }
 
   /**
-   * Creates a new directory stream for the directory located by the given path. The given
-   * {@code basePathForStream} is that base path that the returned stream will use. This will be
-   * the same as {@code dir} except for streams created relative to another secure stream.
+   * Creates a new directory stream for the directory located by the given path. The given {@code
+   * basePathForStream} is that base path that the returned stream will use. This will be the same
+   * as {@code dir} except for streams created relative to another secure stream.
    */
   public DirectoryStream<Path> newDirectoryStream(
       JimfsPath dir,
@@ -134,9 +122,7 @@ final class FileSystemView {
       Set<? super LinkOption> options,
       JimfsPath basePathForStream)
       throws IOException {
-    Directory file = (Directory) lookUpWithLock(dir, options)
-        .requireDirectory(dir)
-        .file();
+    Directory file = (Directory) lookUpWithLock(dir, options).requireDirectory(dir).file();
     FileSystemView view = new FileSystemView(store, file, basePathForStream);
     JimfsSecureDirectoryStream stream = new JimfsSecureDirectoryStream(view, filter, state());
     return store.supportsFeature(Feature.SECURE_DIRECTORY_STREAM)
@@ -144,9 +130,7 @@ final class FileSystemView {
         : new DowngradedDirectoryStream(stream);
   }
 
-  /**
-   * Snapshots the entries of the working directory of this view.
-   */
+  /** Snapshots the entries of the working directory of this view. */
   public ImmutableSortedSet<Name> snapshotWorkingDirectoryEntries() {
     store.readLock().lock();
     try {
@@ -167,9 +151,7 @@ final class FileSystemView {
 
     store.readLock().lock();
     try {
-      Directory dir = (Directory) lookUp(path, Options.FOLLOW_LINKS)
-          .requireDirectory(path)
-          .file();
+      Directory dir = (Directory) lookUp(path, Options.FOLLOW_LINKS).requireDirectory(path).file();
       // TODO(cgdecker): Investigate whether WatchServices should keep a reference to the actual
       // directory when SecureDirectoryStream is supported rather than looking up the directory
       // each time the WatchService polls
@@ -207,8 +189,8 @@ final class FileSystemView {
   }
 
   /**
-   * Gets the {@linkplain Path#toRealPath(LinkOption...) real path} to the file located by the
-   * given path.
+   * Gets the {@linkplain Path#toRealPath(LinkOption...) real path} to the file located by the given
+   * path.
    */
   public JimfsPath toRealPath(
       JimfsPath path, PathService pathService, Set<? super LinkOption> options) throws IOException {
@@ -257,8 +239,8 @@ final class FileSystemView {
 
   /**
    * Creates a new file at the given path if possible, using the given supplier to create the file.
-   * Returns the new file. If {@code allowExisting} is {@code true} and a file already exists at
-   * the given path, returns that file. Otherwise, throws {@link FileAlreadyExistsException}.
+   * Returns the new file. If {@code allowExisting} is {@code true} and a file already exists at the
+   * given path, returns that file. Otherwise, throws {@link FileAlreadyExistsException}.
    */
   private File createFile(
       JimfsPath path,
@@ -343,9 +325,7 @@ final class FileSystemView {
     }
   }
 
-  /**
-   * Gets or creates a new regular file with a write lock (assuming the file does not exist).
-   */
+  /** Gets or creates a new regular file with a write lock (assuming the file does not exist). */
   private RegularFile getOrCreateRegularFileWithWriteLock(
       JimfsPath path, Set<OpenOption> options, FileAttribute<?>[] attrs) throws IOException {
     store.writeLock().lock();
@@ -382,18 +362,15 @@ final class FileSystemView {
     return file;
   }
 
-  /**
-   * Returns the target of the symbolic link at the given path.
-   */
+  /** Returns the target of the symbolic link at the given path. */
   public JimfsPath readSymbolicLink(JimfsPath path) throws IOException {
     if (!store.supportsFeature(Feature.SYMBOLIC_LINKS)) {
       throw new UnsupportedOperationException();
     }
 
     SymbolicLink symbolicLink =
-        (SymbolicLink) lookUpWithLock(path, Options.NOFOLLOW_LINKS)
-            .requireSymbolicLink(path)
-            .file();
+        (SymbolicLink)
+            lookUpWithLock(path, Options.NOFOLLOW_LINKS).requireSymbolicLink(path).file();
 
     return symbolicLink.target();
   }
@@ -436,10 +413,7 @@ final class FileSystemView {
     try {
       // we do want to follow links when finding the existing file
       File existingFile =
-          existingView
-              .lookUp(existing, Options.FOLLOW_LINKS)
-              .requireExists(existing)
-              .file();
+          existingView.lookUp(existing, Options.FOLLOW_LINKS).requireExists(existing).file();
       if (!existingFile.isRegularFile()) {
         throw new FileSystemException(
             link.toString(), existing.toString(), "can't link: not a regular file");
@@ -455,9 +429,7 @@ final class FileSystemView {
     }
   }
 
-  /**
-   * Deletes the file at the given absolute path.
-   */
+  /** Deletes the file at the given absolute path. */
   public void deleteFile(JimfsPath path, DeleteMode deleteMode) throws IOException {
     store.writeLock().lock();
     try {
@@ -468,9 +440,7 @@ final class FileSystemView {
     }
   }
 
-  /**
-   * Deletes the given directory entry from its parent directory.
-   */
+  /** Deletes the given directory entry from its parent directory. */
   private void delete(DirectoryEntry entry, DeleteMode deleteMode, JimfsPath pathForException)
       throws IOException {
     Directory parent = entry.directory();
@@ -483,27 +453,17 @@ final class FileSystemView {
     file.deleted();
   }
 
-  /**
-   * Mode for deleting. Determines what types of files can be deleted.
-   */
+  /** Mode for deleting. Determines what types of files can be deleted. */
   public enum DeleteMode {
-    /**
-     * Delete any file.
-     */
+    /** Delete any file. */
     ANY,
-    /**
-     * Only delete non-directory files.
-     */
+    /** Only delete non-directory files. */
     NON_DIRECTORY_ONLY,
-    /**
-     * Only delete directory files.
-     */
+    /** Only delete directory files. */
     DIRECTORY_ONLY
   }
 
-  /**
-   * Checks that the given file can be deleted, throwing an exception if it can't.
-   */
+  /** Checks that the given file can be deleted, throwing an exception if it can't. */
   private void checkDeletable(File file, DeleteMode mode, Path path) throws IOException {
     if (file.isRootDirectory()) {
       throw new FileSystemException(path.toString(), null, "can't delete root directory");
@@ -527,18 +487,14 @@ final class FileSystemView {
     }
   }
 
-  /**
-   * Checks that given directory is empty, throwing {@link DirectoryNotEmptyException} if not.
-   */
+  /** Checks that given directory is empty, throwing {@link DirectoryNotEmptyException} if not. */
   private void checkEmpty(Directory dir, Path pathForException) throws FileSystemException {
     if (!dir.isEmpty()) {
       throw new DirectoryNotEmptyException(pathForException.toString());
     }
   }
 
-  /**
-   * Copies or moves the file at the given source path to the given dest path.
-   */
+  /** Copies or moves the file at the given source path to the given dest path. */
   public void copy(
       JimfsPath source,
       FileSystemView destView,
@@ -680,9 +636,7 @@ final class FileSystemView {
     }
   }
 
-  /**
-   * Checks that source is not an ancestor of dest, throwing an exception if it is.
-   */
+  /** Checks that source is not an ancestor of dest, throwing an exception if it is. */
   private void checkNotAncestor(File source, Directory destParent, FileSystemView destView)
       throws IOException {
     // if dest is not in the same file system, it couldn't be in source's subdirectories
@@ -722,8 +676,8 @@ final class FileSystemView {
   }
 
   /**
-   * Unlocks source and copy files after copying content. Also closes the source file so its
-   * content can be deleted if it was deleted.
+   * Unlocks source and copy files after copying content. Also closes the source file so its content
+   * can be deleted if it was deleted.
    */
   private void unlockSourceAndCopy(File sourceFile, File copyFile) {
     ReadWriteLock sourceLock = sourceFile.contentLock();
@@ -737,17 +691,13 @@ final class FileSystemView {
     sourceFile.closed();
   }
 
-  /**
-   * Returns a file attribute view using the given lookup callback.
-   */
+  /** Returns a file attribute view using the given lookup callback. */
   @Nullable
   public <V extends FileAttributeView> V getFileAttributeView(FileLookup lookup, Class<V> type) {
     return store.getFileAttributeView(lookup, type);
   }
 
-  /**
-   * Returns a file attribute view for the given path in this view.
-   */
+  /** Returns a file attribute view for the given path in this view. */
   @Nullable
   public <V extends FileAttributeView> V getFileAttributeView(
       final JimfsPath path, Class<V> type, final Set<? super LinkOption> options) {
@@ -755,46 +705,33 @@ final class FileSystemView {
         new FileLookup() {
           @Override
           public File lookup() throws IOException {
-            return lookUpWithLock(path, options)
-                .requireExists(path)
-                .file();
+            return lookUpWithLock(path, options).requireExists(path).file();
           }
         },
         type);
   }
 
-  /**
-   * Reads attributes of the file located by the given path in this view as an object.
-   */
+  /** Reads attributes of the file located by the given path in this view as an object. */
   public <A extends BasicFileAttributes> A readAttributes(
       JimfsPath path, Class<A> type, Set<? super LinkOption> options) throws IOException {
-    File file = lookUpWithLock(path, options)
-        .requireExists(path)
-        .file();
+    File file = lookUpWithLock(path, options).requireExists(path).file();
     return store.readAttributes(file, type);
   }
 
-  /**
-   * Reads attributes of the file located by the given path in this view as a map.
-   */
+  /** Reads attributes of the file located by the given path in this view as a map. */
   public ImmutableMap<String, Object> readAttributes(
       JimfsPath path, String attributes, Set<? super LinkOption> options) throws IOException {
-    File file = lookUpWithLock(path, options)
-        .requireExists(path)
-        .file();
+    File file = lookUpWithLock(path, options).requireExists(path).file();
     return store.readAttributes(file, attributes);
   }
 
   /**
-   * Sets the given attribute to the given value on the file located by the given path in this
-   * view.
+   * Sets the given attribute to the given value on the file located by the given path in this view.
    */
   public void setAttribute(
       JimfsPath path, String attribute, Object value, Set<? super LinkOption> options)
       throws IOException {
-    File file = lookUpWithLock(path, options)
-        .requireExists(path)
-        .file();
+    File file = lookUpWithLock(path, options).requireExists(path).file();
     store.setAttribute(file, attribute, value);
   }
 }

--- a/jimfs/src/main/java/com/google/common/jimfs/FileTree.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileTree.java
@@ -21,14 +21,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
-
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 
 /**
@@ -40,29 +38,23 @@ import javax.annotation.Nullable;
 final class FileTree {
 
   /**
-   * Doesn't much matter, but this number comes from MIN_ELOOP_THRESHOLD
-   * <a href="https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=blob_plain;f=sysdeps/generic/eloop-threshold.h;hb=HEAD">
+   * Doesn't much matter, but this number comes from MIN_ELOOP_THRESHOLD <a
+   * href="https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=blob_plain;f=sysdeps/generic/eloop-threshold.h;hb=HEAD">
    * here</a>
    */
   private static final int MAX_SYMBOLIC_LINK_DEPTH = 40;
 
   private static final ImmutableList<Name> EMPTY_PATH_NAMES = ImmutableList.of(Name.SELF);
 
-  /**
-   * Map of root names to root directories.
-   */
+  /** Map of root names to root directories. */
   private final ImmutableSortedMap<Name, Directory> roots;
 
-  /**
-   * Creates a new file tree with the given root directories.
-   */
+  /** Creates a new file tree with the given root directories. */
   FileTree(Map<Name, Directory> roots) {
     this.roots = ImmutableSortedMap.copyOf(roots, Name.canonicalOrdering());
   }
 
-  /**
-   * Returns the names of the root directories in this tree.
-   */
+  /** Returns the names of the root directories in this tree. */
   public ImmutableSortedSet<Name> getRootDirectoryNames() {
     return roots.keySet();
   }
@@ -77,9 +69,7 @@ final class FileTree {
     return dir == null ? null : dir.entryInParent();
   }
 
-  /**
-   * Returns the result of the file lookup for the given path.
-   */
+  /** Returns the result of the file lookup for the given path. */
   public DirectoryEntry lookUp(
       File workingDirectory, JimfsPath path, Set<? super LinkOption> options) throws IOException {
     checkNotNull(path);
@@ -160,9 +150,7 @@ final class FileTree {
     return lookUpLast(dir, name, options, linkDepth);
   }
 
-  /**
-   * Looks up the last element of a path.
-   */
+  /** Looks up the last element of a path. */
   @Nullable
   private DirectoryEntry lookUpLast(
       @Nullable File dir, Name name, Set<? super LinkOption> options, int linkDepth)
@@ -205,8 +193,8 @@ final class FileTree {
    * parent directory. In that case, we know the file must be a directory ("." and ".." can only
    * link to directories), so we can just get the entry in the directory's parent directory that
    * links to it. So, for example, if we have a directory "foo" that contains a directory "bar" and
-   * we find an entry [bar -> "." -> bar], we instead return the entry for bar in its parent,
-   * [foo -> "bar" -> bar].
+   * we find an entry [bar -> "." -> bar], we instead return the entry for bar in its parent, [foo
+   * -> "bar" -> bar].
    */
   @Nullable
   private DirectoryEntry getRealEntry(DirectoryEntry entry) {
@@ -228,7 +216,6 @@ final class FileTree {
 
   private static boolean isEmpty(ImmutableList<Name> names) {
     // the empty path (created by FileSystem.getPath("")), has no root and a single name, ""
-    return names.isEmpty()
-        || names.size() == 1 && names.get(0).toString().isEmpty();
+    return names.isEmpty() || names.size() == 1 && names.get(0).toString().isEmpty();
   }
 }

--- a/jimfs/src/main/java/com/google/common/jimfs/GlobToRegex.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/GlobToRegex.java
@@ -82,44 +82,32 @@ final class GlobToRegex {
     return builder.toString();
   }
 
-  /**
-   * Enters the given state. The current state becomes the previous state.
-   */
+  /** Enters the given state. The current state becomes the previous state. */
   private void pushState(State state) {
     states.push(state);
   }
 
-  /**
-   * Returns to the previous state.
-   */
+  /** Returns to the previous state. */
   private void popState() {
     states.pop();
   }
 
-  /**
-   * Returns the current state.
-   */
+  /** Returns the current state. */
   private State currentState() {
     return states.peek();
   }
 
-  /**
-   * Throws a {@link PatternSyntaxException}.
-   */
+  /** Throws a {@link PatternSyntaxException}. */
   private PatternSyntaxException syntaxError(String desc) {
     throw new PatternSyntaxException(desc, glob, index);
   }
 
-  /**
-   * Appends the given character as-is to the regex.
-   */
+  /** Appends the given character as-is to the regex. */
   private void appendExact(char c) {
     builder.append(c);
   }
 
-  /**
-   * Appends the regex form of the given normal character or separator from the glob.
-   */
+  /** Appends the regex form of the given normal character or separator from the glob. */
   private void append(char c) {
     if (separatorMatcher.matches(c)) {
       appendSeparator();
@@ -128,9 +116,7 @@ final class GlobToRegex {
     }
   }
 
-  /**
-   * Appends the regex form of the given normal character from the glob.
-   */
+  /** Appends the regex form of the given normal character from the glob. */
   private void appendNormal(char c) {
     if (REGEX_RESERVED.matches(c)) {
       builder.append('\\');
@@ -138,9 +124,7 @@ final class GlobToRegex {
     builder.append(c);
   }
 
-  /**
-   * Appends the regex form matching the separators for the path type.
-   */
+  /** Appends the regex form matching the separators for the path type. */
   private void appendSeparator() {
     if (separators.length() == 1) {
       appendNormal(separators.charAt(0));
@@ -153,9 +137,7 @@ final class GlobToRegex {
     }
   }
 
-  /**
-   * Appends the regex form that matches anything except the separators for the path type.
-   */
+  /** Appends the regex form that matches anything except the separators for the path type. */
   private void appendNonSeparator() {
     builder.append("[^");
     for (int i = 0; i < separators.length(); i++) {
@@ -164,47 +146,35 @@ final class GlobToRegex {
     builder.append(']');
   }
 
-  /**
-   * Appends the regex form of the glob ? character.
-   */
+  /** Appends the regex form of the glob ? character. */
   private void appendQuestionMark() {
     appendNonSeparator();
   }
 
-  /**
-   * Appends the regex form of the glob * character.
-   */
+  /** Appends the regex form of the glob * character. */
   private void appendStar() {
     appendNonSeparator();
     builder.append('*');
   }
 
-  /**
-   * Appends the regex form of the glob ** pattern.
-   */
+  /** Appends the regex form of the glob ** pattern. */
   private void appendStarStar() {
     builder.append(".*");
   }
 
-  /**
-   * Appends the regex form of the start of a glob [] section.
-   */
+  /** Appends the regex form of the start of a glob [] section. */
   private void appendBracketStart() {
     builder.append('[');
     appendNonSeparator();
     builder.append("&&[");
   }
 
-  /**
-   * Appends the regex form of the end of a glob [] section.
-   */
+  /** Appends the regex form of the end of a glob [] section. */
   private void appendBracketEnd() {
     builder.append("]]");
   }
 
-  /**
-   * Appends the regex form of the given character within a glob [] section.
-   */
+  /** Appends the regex form of the given character within a glob [] section. */
   private void appendInBracket(char c) {
     // escape \ in regex character class
     if (c == '\\') {
@@ -214,46 +184,34 @@ final class GlobToRegex {
     builder.append(c);
   }
 
-  /**
-   * Appends the regex form of the start of a glob {} section.
-   */
+  /** Appends the regex form of the start of a glob {} section. */
   private void appendCurlyBraceStart() {
     builder.append('(');
   }
 
-  /**
-   * Appends the regex form of the separator (,) within a glob {} section.
-   */
+  /** Appends the regex form of the separator (,) within a glob {} section. */
   private void appendSubpatternSeparator() {
     builder.append('|');
   }
 
-  /**
-   * Appends the regex form of the end of a glob {} section.
-   */
+  /** Appends the regex form of the end of a glob {} section. */
   private void appendCurlyBraceEnd() {
     builder.append(')');
   }
 
-  /**
-   * Converter state.
-   */
+  /** Converter state. */
   private abstract static class State {
     /**
-     * Process the next character with the current state, transitioning the converter to a new
-     * state if necessary.
+     * Process the next character with the current state, transitioning the converter to a new state
+     * if necessary.
      */
     abstract void process(GlobToRegex converter, char c);
 
-    /**
-     * Called after all characters have been read.
-     */
+    /** Called after all characters have been read. */
     void finish(GlobToRegex converter) {}
   }
 
-  /**
-   * Normal state.
-   */
+  /** Normal state. */
   private static final State NORMAL =
       new State() {
         @Override
@@ -287,9 +245,7 @@ final class GlobToRegex {
         }
       };
 
-  /**
-   * State following the reading of a single \.
-   */
+  /** State following the reading of a single \. */
   private static final State ESCAPE =
       new State() {
         @Override
@@ -309,9 +265,7 @@ final class GlobToRegex {
         }
       };
 
-  /**
-   * State following the reading of a single *.
-   */
+  /** State following the reading of a single *. */
   private static final State STAR =
       new State() {
         @Override
@@ -337,17 +291,15 @@ final class GlobToRegex {
         }
       };
 
-  /**
-   * State immediately following the reading of a [.
-   */
+  /** State immediately following the reading of a [. */
   private static final State BRACKET_FIRST_CHAR =
       new State() {
         @Override
         void process(GlobToRegex converter, char c) {
           if (c == ']') {
-            // A glob like "[]]" or "[]q]" is apparently fine in Unix (when used with ls for example)
-            // but doesn't work for the default java.nio.file implementations. In the cases of "[]]" it
-            // produces:
+            // A glob like "[]]" or "[]q]" is apparently fine in Unix (when used with ls for
+            // example) but doesn't work for the default java.nio.file implementations. In the cases
+            // of "[]]" it produces:
             // java.util.regex.PatternSyntaxException: Unclosed character class near index 13
             // ^[[^/]&&[]]\]$
             //              ^
@@ -378,9 +330,7 @@ final class GlobToRegex {
         }
       };
 
-  /**
-   * State inside [brackets], but not at the first character inside the brackets.
-   */
+  /** State inside [brackets], but not at the first character inside the brackets. */
   private static final State BRACKET =
       new State() {
         @Override
@@ -404,9 +354,7 @@ final class GlobToRegex {
         }
       };
 
-  /**
-   * State inside {curly braces}.
-   */
+  /** State inside {curly braces}. */
   private static final State CURLY_BRACE =
       new State() {
         @Override

--- a/jimfs/src/main/java/com/google/common/jimfs/Handler.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Handler.java
@@ -24,12 +24,12 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
 /**
- * {@link URLStreamHandler} implementation for jimfs. Named {@code Handler} so that the class can
- * be found by Java as described in the documentation for
- * {@link URL#URL(String, String, int, String) URL}.
+ * {@link URLStreamHandler} implementation for jimfs. Named {@code Handler} so that the class can be
+ * found by Java as described in the documentation for {@link URL#URL(String, String, int, String)
+ * URL}.
  *
- * <p>This class is only public because it is necessary for Java to find it. It is not intended
- * to be used directly.
+ * <p>This class is only public because it is necessary for Java to find it. It is not intended to
+ * be used directly.
  *
  * @author Colin Decker
  * @since 1.1
@@ -50,9 +50,7 @@ public final class Handler extends URLStreamHandler {
     register(Handler.class);
   }
 
-  /**
-   * Generic method that would allow registration of any properly placed {@code Handler} class.
-   */
+  /** Generic method that would allow registration of any properly placed {@code Handler} class. */
   static void register(Class<? extends URLStreamHandler> handlerClass) {
     checkArgument("Handler".equals(handlerClass.getSimpleName()));
 
@@ -71,9 +69,7 @@ public final class Handler extends URLStreamHandler {
     System.setProperty(JAVA_PROTOCOL_HANDLER_PACKAGES, packages);
   }
 
-  /**
-   * @deprecated Not intended to be called directly; this class is only for use by Java itself.
-   */
+  /** @deprecated Not intended to be called directly; this class is only for use by Java itself. */
   @Deprecated
   public Handler() {} // a public, no-arg constructor is required
 

--- a/jimfs/src/main/java/com/google/common/jimfs/HeapDisk.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/HeapDisk.java
@@ -20,16 +20,15 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.math.LongMath;
-
 import java.io.IOException;
 import java.math.RoundingMode;
 
 /**
  * A resizable pseudo-disk acting as a shared space for storing file data. A disk allocates fixed
  * size blocks of bytes to files as needed and may cache blocks that have been freed for reuse. A
- * memory disk has a fixed maximum number of blocks it will allocate at a time (which sets the
- * total "size" of the disk) and a maximum number of unused blocks it will cache for reuse at a
- * time (which sets the minimum amount of space the disk will use once
+ * memory disk has a fixed maximum number of blocks it will allocate at a time (which sets the total
+ * "size" of the disk) and a maximum number of unused blocks it will cache for reuse at a time
+ * (which sets the minimum amount of space the disk will use once
  *
  * @author Colin Decker
  */
@@ -53,9 +52,7 @@ final class HeapDisk {
   /** The current total number of blocks that are currently allocated to files. */
   private int allocatedBlockCount;
 
-  /**
-   * Creates a new disk using settings from the given configuration.
-   */
+  /** Creates a new disk using settings from the given configuration. */
   public HeapDisk(Configuration config) {
     this.blockSize = config.blockSize;
     this.maxBlockCount = toBlockCount(config.maxSize, blockSize);
@@ -64,14 +61,14 @@ final class HeapDisk {
     this.blockCache = createBlockCache(maxCachedBlockCount);
   }
 
-  /**  Returns the nearest multiple of {@code blockSize} that is <= {@code size}. */
+  /** Returns the nearest multiple of {@code blockSize} that is <= {@code size}. */
   private static int toBlockCount(long size, int blockSize) {
     return (int) LongMath.divide(size, blockSize, RoundingMode.FLOOR);
   }
 
   /**
-   * Creates a new disk with the given {@code blockSize}, {@code maxBlockCount} and
-   * {@code maxCachedBlockCount}.
+   * Creates a new disk with the given {@code blockSize}, {@code maxBlockCount} and {@code
+   * maxCachedBlockCount}.
    */
   public HeapDisk(int blockSize, int maxBlockCount, int maxCachedBlockCount) {
     checkArgument(blockSize > 0, "blockSize (%s) must be positive", blockSize);
@@ -88,9 +85,7 @@ final class HeapDisk {
     return new RegularFile(-1, this, new byte[Math.min(maxCachedBlockCount, 8192)][], 0, 0);
   }
 
-  /**
-   * Returns the size of blocks created by this disk.
-   */
+  /** Returns the size of blocks created by this disk. */
   public int blockSize() {
     return blockSize;
   }
@@ -112,9 +107,7 @@ final class HeapDisk {
     return (maxBlockCount - allocatedBlockCount) * (long) blockSize;
   }
 
-  /**
-   * Allocates the given number of blocks and adds them to the given file.
-   */
+  /** Allocates the given number of blocks and adds them to the given file. */
   public synchronized void allocate(RegularFile file, int count) throws IOException {
     int newAllocatedBlockCount = allocatedBlockCount + count;
     if (newAllocatedBlockCount > maxBlockCount) {
@@ -134,16 +127,12 @@ final class HeapDisk {
     allocatedBlockCount = newAllocatedBlockCount;
   }
 
-  /**
-   * Frees all blocks in the given file.
-   */
+  /** Frees all blocks in the given file. */
   public void free(RegularFile file) {
     free(file, file.blockCount());
   }
 
-  /**
-   * Frees the last {@code count} blocks from the given file.
-   */
+  /** Frees the last {@code count} blocks from the given file. */
   public synchronized void free(RegularFile file, int count) {
     int remainingCacheSpace = maxCachedBlockCount - blockCache.blockCount();
     if (remainingCacheSpace > 0) {

--- a/jimfs/src/main/java/com/google/common/jimfs/Jimfs.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Jimfs.java
@@ -21,7 +21,6 @@ import static com.google.common.jimfs.SystemJimfsFileSystemProvider.FILE_SYSTEM_
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -34,15 +33,14 @@ import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
 
 /**
  * Static factory methods for creating new Jimfs file systems. File systems may either be created
  * with a basic configuration matching the current operating system or by providing a specific
- * {@link Configuration}. Basic {@linkplain Configuration#unix() UNIX},
- * {@linkplain Configuration#osX() Mac OS X} and {@linkplain Configuration#windows() Windows}
- * configurations are provided.
+ * {@link Configuration}. Basic {@linkplain Configuration#unix() UNIX}, {@linkplain
+ * Configuration#osX() Mac OS X} and {@linkplain Configuration#windows() Windows} configurations are
+ * provided.
  *
  * <p>Examples:
  *
@@ -80,9 +78,7 @@ import javax.annotation.Nullable;
  */
 public final class Jimfs {
 
-  /**
-   * The URI scheme for the Jimfs file system ("jimfs").
-   */
+  /** The URI scheme for the Jimfs file system ("jimfs"). */
   public static final String URI_SCHEME = "jimfs";
 
   private static final Logger LOGGER = Logger.getLogger(Jimfs.class.getName());
@@ -90,9 +86,8 @@ public final class Jimfs {
   private Jimfs() {}
 
   /**
-   * Creates a new in-memory file system with a
-   * {@linkplain Configuration#forCurrentPlatform() default configuration} appropriate to the
-   * current operating system.
+   * Creates a new in-memory file system with a {@linkplain Configuration#forCurrentPlatform()
+   * default configuration} appropriate to the current operating system.
    *
    * <p>More specifically, if the operating system is Windows, {@link Configuration#windows()} is
    * used; if the operating system is Mac OS X, {@link Configuration#osX()} is used; otherwise,
@@ -103,26 +98,23 @@ public final class Jimfs {
   }
 
   /**
-   * Creates a new in-memory file system with a
-   * {@linkplain Configuration#forCurrentPlatform() default configuration} appropriate to the
-   * current operating system.
+   * Creates a new in-memory file system with a {@linkplain Configuration#forCurrentPlatform()
+   * default configuration} appropriate to the current operating system.
    *
    * <p>More specifically, if the operating system is Windows, {@link Configuration#windows()} is
    * used; if the operating system is Mac OS X, {@link Configuration#osX()} is used; otherwise,
    * {@link Configuration#unix()} is used.
    *
    * <p>The returned file system uses the given name as the host part of its URI and the URIs of
-   * paths in the file system. For example, given the name {@code my-file-system}, the file
-   * system's URI will be {@code jimfs://my-file-system} and the URI of the path {@code /foo/bar}
-   * will be {@code jimfs://my-file-system/foo/bar}.
+   * paths in the file system. For example, given the name {@code my-file-system}, the file system's
+   * URI will be {@code jimfs://my-file-system} and the URI of the path {@code /foo/bar} will be
+   * {@code jimfs://my-file-system/foo/bar}.
    */
   public static FileSystem newFileSystem(String name) {
     return newFileSystem(name, Configuration.forCurrentPlatform());
   }
 
-  /**
-   * Creates a new in-memory file system with the given configuration.
-   */
+  /** Creates a new in-memory file system with the given configuration. */
   public static FileSystem newFileSystem(Configuration configuration) {
     return newFileSystem(newRandomFileSystemName(), configuration);
   }
@@ -131,9 +123,9 @@ public final class Jimfs {
    * Creates a new in-memory file system with the given configuration.
    *
    * <p>The returned file system uses the given name as the host part of its URI and the URIs of
-   * paths in the file system. For example, given the name {@code my-file-system}, the file
-   * system's URI will be {@code jimfs://my-file-system} and the URI of the path {@code /foo/bar}
-   * will be {@code jimfs://my-file-system/foo/bar}.
+   * paths in the file system. For example, given the name {@code my-file-system}, the file system's
+   * URI will be {@code jimfs://my-file-system} and the URI of the path {@code /foo/bar} will be
+   * {@code jimfs://my-file-system/foo/bar}.
    */
   public static FileSystem newFileSystem(String name, Configuration configuration) {
     try {
@@ -179,23 +171,22 @@ public final class Jimfs {
   }
 
   /**
-   * The system-loaded instance of {@code SystemJimfsFileSystemProvider}, or {@code null}
-   * if it could not be found or loaded.
+   * The system-loaded instance of {@code SystemJimfsFileSystemProvider}, or {@code null} if it
+   * could not be found or loaded.
    */
-  @Nullable
-  static final FileSystemProvider systemProvider = getSystemJimfsProvider();
+  @Nullable static final FileSystemProvider systemProvider = getSystemJimfsProvider();
 
   /**
-   * Returns the system-loaded instance of {@code SystemJimfsFileSystemProvider} or {@code null}
-   * if it could not be found or loaded.
+   * Returns the system-loaded instance of {@code SystemJimfsFileSystemProvider} or {@code null} if
+   * it could not be found or loaded.
    *
    * <p>Like {@link FileSystems#newFileSystem(URI, Map, ClassLoader)}, this method first looks in
-   * the list of {@linkplain FileSystemProvider#installedProviders() installed providers} and if
-   * not found there, attempts to load it from the {@code ClassLoader} with {@link ServiceLoader}.
+   * the list of {@linkplain FileSystemProvider#installedProviders() installed providers} and if not
+   * found there, attempts to load it from the {@code ClassLoader} with {@link ServiceLoader}.
    *
-   * <p>The idea is that this method should return an instance of the same class (i.e. loaded by
-   * the same class loader) as the class whose static cache a {@code JimfsFileSystem} instance will
-   * be placed in when {@code FileSystems.newFileSystem} is called in {@code Jimfs.newFileSystem}.
+   * <p>The idea is that this method should return an instance of the same class (i.e. loaded by the
+   * same class loader) as the class whose static cache a {@code JimfsFileSystem} instance will be
+   * placed in when {@code FileSystems.newFileSystem} is called in {@code Jimfs.newFileSystem}.
    */
   @Nullable
   private static FileSystemProvider getSystemJimfsProvider() {

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsAsynchronousFileChannel.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsAsynchronousFileChannel.java
@@ -23,7 +23,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
@@ -33,7 +32,6 @@ import java.nio.channels.FileLock;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-
 import javax.annotation.Nullable;
 
 /**
@@ -179,18 +177,14 @@ final class JimfsAsynchronousFileChannel extends AsynchronousFileChannel {
     channel.close();
   }
 
-  /**
-   * Immediate future indicating that the channel is closed.
-   */
+  /** Immediate future indicating that the channel is closed. */
   private static <V> ListenableFuture<V> closedChannelFuture() {
     SettableFuture<V> future = SettableFuture.create();
     future.setException(new ClosedChannelException());
     return future;
   }
 
-  /**
-   * Runnable callback that wraps a {@link CompletionHandler} and an attachment.
-   */
+  /** Runnable callback that wraps a {@link CompletionHandler} and an attachment. */
   private static final class CompletionHandlerCallback<R, A> implements Runnable {
 
     private final ListenableFuture<R> future;

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
@@ -43,8 +43,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
@@ -652,9 +650,7 @@ final class JimfsFileChannel extends FileChannel {
     }
   }
 
-  /**
-   * A file lock that does nothing, since only one JVM process has access to this file system.
-   */
+  /** A file lock that does nothing, since only one JVM process has access to this file system. */
   static final class FakeFileLock extends FileLock {
 
     private final AtomicBoolean valid = new AtomicBoolean(true);

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
@@ -22,7 +22,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.LinkOption;
@@ -35,7 +34,6 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import javax.annotation.Nullable;
 
 /**
@@ -82,47 +80,35 @@ final class JimfsFileStore extends FileStore {
 
   // internal use methods
 
-  /**
-   * Returns the file system state object.
-   */
+  /** Returns the file system state object. */
   FileSystemState state() {
     return state;
   }
 
-  /**
-   * Returns the read lock for this store.
-   */
+  /** Returns the read lock for this store. */
   Lock readLock() {
     return readLock;
   }
 
-  /**
-   * Returns the write lock for this store.
-   */
+  /** Returns the write lock for this store. */
   Lock writeLock() {
     return writeLock;
   }
 
-  /**
-   * Returns the names of the root directories in this store.
-   */
+  /** Returns the names of the root directories in this store. */
   ImmutableSortedSet<Name> getRootDirectoryNames() {
     state.checkOpen();
     return tree.getRootDirectoryNames();
   }
 
-  /**
-   * Returns the root directory with the given name or {@code null} if no such directory exists.
-   */
+  /** Returns the root directory with the given name or {@code null} if no such directory exists. */
   @Nullable
   Directory getRoot(Name name) {
     DirectoryEntry entry = tree.getRoot(name);
     return entry == null ? null : (Directory) entry.file();
   }
 
-  /**
-   * Returns whether or not the given feature is supported by this file store.
-   */
+  /** Returns whether or not the given feature is supported by this file store. */
   boolean supportsFeature(Feature feature) {
     return supportedFeatures.contains(feature);
   }
@@ -134,7 +120,7 @@ final class JimfsFileStore extends FileStore {
    * @throws NoSuchFileException if an element of the path other than the final element does not
    *     resolve to a directory or symbolic link (e.g. it doesn't exist or is a regular file)
    * @throws IOException if a symbolic link cycle is detected or the depth of symbolic link
-   *    recursion otherwise exceeds a threshold
+   *     recursion otherwise exceeds a threshold
    */
   DirectoryEntry lookUp(File workingDirectory, JimfsPath path, Set<? super LinkOption> options)
       throws IOException {
@@ -142,33 +128,27 @@ final class JimfsFileStore extends FileStore {
     return tree.lookUp(workingDirectory, path, options);
   }
 
-  /**
-   * Returns a supplier that creates a new regular file.
-   */
+  /** Returns a supplier that creates a new regular file. */
   Supplier<RegularFile> regularFileCreator() {
     state.checkOpen();
     return factory.regularFileCreator();
   }
 
-  /**
-   * Returns a supplier that creates a new directory.
-   */
+  /** Returns a supplier that creates a new directory. */
   Supplier<Directory> directoryCreator() {
     state.checkOpen();
     return factory.directoryCreator();
   }
 
-  /**
-   * Returns a supplier that creates a new symbolic link with the given target.
-   */
+  /** Returns a supplier that creates a new symbolic link with the given target. */
   Supplier<SymbolicLink> symbolicLinkCreator(JimfsPath target) {
     state.checkOpen();
     return factory.symbolicLinkCreator(target);
   }
 
   /**
-   * Creates a copy of the given file, copying its attributes as well according to the given
-   * {@code attributeCopyOption}.
+   * Creates a copy of the given file, copying its attributes as well according to the given {@code
+   * attributeCopyOption}.
    */
   File copyWithoutContent(File file, AttributeCopyOption attributeCopyOption) throws IOException {
     File copy = factory.copyWithoutContent(file);
@@ -187,8 +167,8 @@ final class JimfsFileStore extends FileStore {
   }
 
   /**
-   * Returns an attribute view of the given type for the given file lookup callback, or
-   * {@code null} if the view type is not supported.
+   * Returns an attribute view of the given type for the given file lookup callback, or {@code null}
+   * if the view type is not supported.
    */
   @Nullable
   <V extends FileAttributeView> V getFileAttributeView(FileLookup lookup, Class<V> type) {
@@ -214,18 +194,14 @@ final class JimfsFileStore extends FileStore {
     return attributes.readAttributes(file, type);
   }
 
-  /**
-   * Sets the given attribute to the given value for the given file.
-   */
+  /** Sets the given attribute to the given value for the given file. */
   void setAttribute(File file, String attribute, Object value) {
     state.checkOpen();
     // TODO(cgdecker): Change attribute stuff to avoid the sad boolean parameter
     attributes.setAttribute(file, attribute, value, false);
   }
 
-  /**
-   * Returns the file attribute views supported by this store.
-   */
+  /** Returns the file attribute views supported by this store. */
   ImmutableSet<String> supportedFileAttributeViews() {
     state.checkOpen();
     return attributes.supportedFileAttributeViews();

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystem.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystem.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
@@ -34,128 +33,125 @@ import java.nio.file.WatchService;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 import javax.annotation.Nullable;
 
 /**
- * {@link FileSystem} implementation for Jimfs. Most behavior for the file system is implemented
- * by its {@linkplain #getDefaultView() default file system view}.
+ * {@link FileSystem} implementation for Jimfs. Most behavior for the file system is implemented by
+ * its {@linkplain #getDefaultView() default file system view}.
  *
  * <h3>Overview of file system design</h3>
  *
- * {@link com.google.common.jimfs.JimfsFileSystem JimfsFileSystem} instances are created by
- * {@link com.google.common.jimfs.JimfsFileSystems JimfsFileSystems} using a user-provided
- * {@link com.google.common.jimfs.Configuration Configuration}. The configuration is used to create
- * the various classes that implement the file system with the correct settings and to create the
- * file system root directories and working directory. The file system is then used to create the
- * {@code Path} objects that all file system operations use.
+ * {@link com.google.common.jimfs.JimfsFileSystem JimfsFileSystem} instances are created by {@link
+ * com.google.common.jimfs.JimfsFileSystems JimfsFileSystems} using a user-provided {@link
+ * com.google.common.jimfs.Configuration Configuration}. The configuration is used to create the
+ * various classes that implement the file system with the correct settings and to create the file
+ * system root directories and working directory. The file system is then used to create the {@code
+ * Path} objects that all file system operations use.
  *
- * <p>Once created, the primary entry points to the file system are
- * {@link com.google.common.jimfs.JimfsFileSystemProvider JimfsFileSystemProvider}, which handles
- * calls to methods in {@link java.nio.file.Files}, and
- * {@link com.google.common.jimfs.JimfsSecureDirectoryStream JimfsSecureDirectoryStream}, which
- * provides methods that are similar to those of the file system provider but which treat relative
- * paths as relative to the stream's directory rather than the file system's working directory.
+ * <p>Once created, the primary entry points to the file system are {@link
+ * com.google.common.jimfs.JimfsFileSystemProvider JimfsFileSystemProvider}, which handles calls to
+ * methods in {@link java.nio.file.Files}, and {@link
+ * com.google.common.jimfs.JimfsSecureDirectoryStream JimfsSecureDirectoryStream}, which provides
+ * methods that are similar to those of the file system provider but which treat relative paths as
+ * relative to the stream's directory rather than the file system's working directory.
  *
- * <p>The implementation of the methods on both of those classes is handled by the
- * {@link com.google.common.jimfs.FileSystemView FileSystemView} class, which acts as a view of
- * the file system with a specific working directory. The file system provider uses the file
- * system's default view, while each secure directory stream uses a view specific to that stream.
+ * <p>The implementation of the methods on both of those classes is handled by the {@link
+ * com.google.common.jimfs.FileSystemView FileSystemView} class, which acts as a view of the file
+ * system with a specific working directory. The file system provider uses the file system's default
+ * view, while each secure directory stream uses a view specific to that stream.
  *
- * <p>File system views make use of the file system's singleton
- * {@link com.google.common.jimfs.JimfsFileStore JimfsFileStore} which handles file creation,
- * storage and attributes. The file store delegates to several other classes to handle each of
- * these:
+ * <p>File system views make use of the file system's singleton {@link
+ * com.google.common.jimfs.JimfsFileStore JimfsFileStore} which handles file creation, storage and
+ * attributes. The file store delegates to several other classes to handle each of these:
  *
  * <ul>
  *   <li>{@link com.google.common.jimfs.FileFactory FileFactory} handles creation of new file
- *   objects.</li>
- *   <li>{@link com.google.common.jimfs.HeapDisk HeapDisk} handles allocation of blocks to
- *   {@link RegularFile RegularFile} instances.</li>
- *   <li>{@link com.google.common.jimfs.FileTree FileTree} stores the root of the file hierarchy
- *   and handles file lookup.</li>
- *   <li>{@link com.google.common.jimfs.AttributeService AttributeService} handles file
- *   attributes, using a set of
- *   {@link com.google.common.jimfs.AttributeProvider AttributeProvider} implementations to
- *   handle each supported file attribute view.</li>
+ *       objects.
+ *   <li>{@link com.google.common.jimfs.HeapDisk HeapDisk} handles allocation of blocks to {@link
+ *       RegularFile RegularFile} instances.
+ *   <li>{@link com.google.common.jimfs.FileTree FileTree} stores the root of the file hierarchy and
+ *       handles file lookup.
+ *   <li>{@link com.google.common.jimfs.AttributeService AttributeService} handles file attributes,
+ *       using a set of {@link com.google.common.jimfs.AttributeProvider AttributeProvider}
+ *       implementations to handle each supported file attribute view.
  * </ul>
  *
  * <h3>Paths</h3>
  *
- * The implementation of {@link java.nio.file.Path} for the file system is
- * {@link com.google.common.jimfs.JimfsPath JimfsPath}. Paths are created by a
- * {@link com.google.common.jimfs.PathService PathService} with help from the file system's
- * configured {@link com.google.common.jimfs.PathType PathType}.
+ * The implementation of {@link java.nio.file.Path} for the file system is {@link
+ * com.google.common.jimfs.JimfsPath JimfsPath}. Paths are created by a {@link
+ * com.google.common.jimfs.PathService PathService} with help from the file system's configured
+ * {@link com.google.common.jimfs.PathType PathType}.
  *
  * <p>Paths are made up of {@link com.google.common.jimfs.Name Name} objects, which also serve as
  * the file names in directories. A name has two forms:
  *
  * <ul>
  *   <li>The <b>display form</b> is used in {@code Path} for {@code toString()}. It is also used for
- *   determining the equality and sort order of {@code Path} objects for most file systems.</li>
+ *       determining the equality and sort order of {@code Path} objects for most file systems.
  *   <li>The <b>canonical form</b> is used for equality of two {@code Name} objects. This affects
- *   the notion of name equality in the file system itself for file lookup. A file system may be
- *   configured to use the canonical form of the name for path equality (a Windows-like file system
- *   configuration does this, as the real Windows file system implementation uses case-insensitive
- *   equality for its path objects.</li>
+ *       the notion of name equality in the file system itself for file lookup. A file system may be
+ *       configured to use the canonical form of the name for path equality (a Windows-like file
+ *       system configuration does this, as the real Windows file system implementation uses
+ *       case-insensitive equality for its path objects.
  * </ul>
  *
- * <p>The canonical form of a name is created by applying a series of
- * {@linkplain PathNormalization normalizations} to the original string. These
- * normalization may be either a Unicode normalization (e.g. NFD) or case folding normalization for
- * case-insensitivity. Normalizations may also be applied to the display form of a name, but this
- * is currently only done for a Mac OS X type configuration.
+ * <p>The canonical form of a name is created by applying a series of {@linkplain PathNormalization
+ * normalizations} to the original string. These normalization may be either a Unicode normalization
+ * (e.g. NFD) or case folding normalization for case-insensitivity. Normalizations may also be
+ * applied to the display form of a name, but this is currently only done for a Mac OS X type
+ * configuration.
  *
  * <h3>Files</h3>
  *
- * All files in the file system are an instance of {@link com.google.common.jimfs.File File}. A
- * file object contains both the file's attributes and content.
+ * All files in the file system are an instance of {@link com.google.common.jimfs.File File}. A file
+ * object contains both the file's attributes and content.
  *
  * <p>There are three types of files:
  *
  * <ul>
- *   <li>{@link Directory Directory} - contains a table linking file names
- *   to {@linkplain com.google.common.jimfs.DirectoryEntry directory entries}.
+ *   <li>{@link Directory Directory} - contains a table linking file names to {@linkplain
+ *       com.google.common.jimfs.DirectoryEntry directory entries}.
  *   <li>{@link RegularFile RegularFile} - an in-memory store for raw bytes.
  *   <li>{@link com.google.common.jimfs.SymbolicLink SymbolicLink} - contains a path.
  * </ul>
  *
- * <p>{@link com.google.common.jimfs.JimfsFileChannel JimfsFileChannel},
- * {@link com.google.common.jimfs.JimfsInputStream JimfsInputStream} and
- * {@link com.google.common.jimfs.JimfsOutputStream JimfsOutputStream} implement the standard
+ * <p>{@link com.google.common.jimfs.JimfsFileChannel JimfsFileChannel}, {@link
+ * com.google.common.jimfs.JimfsInputStream JimfsInputStream} and {@link
+ * com.google.common.jimfs.JimfsOutputStream JimfsOutputStream} implement the standard
  * channel/stream APIs for regular files.
  *
  * <p>{@link com.google.common.jimfs.JimfsSecureDirectoryStream JimfsSecureDirectoryStream} handles
- * reading the entries of a directory. The secure directory stream additionally contains a
- * {@code FileSystemView} with its directory as the working directory, allowing for operations
- * relative to the actual directory file rather than just the path to the file. This allows the
- * operations to continue to work as expected even if the directory is moved.
+ * reading the entries of a directory. The secure directory stream additionally contains a {@code
+ * FileSystemView} with its directory as the working directory, allowing for operations relative to
+ * the actual directory file rather than just the path to the file. This allows the operations to
+ * continue to work as expected even if the directory is moved.
  *
  * <p>A directory can be watched for changes using the {@link java.nio.file.WatchService}
  * implementation, {@link com.google.common.jimfs.PollingWatchService PollingWatchService}.
  *
  * <h3>Regular files</h3>
  *
- * {@link RegularFile RegularFile} makes use of a singleton
- * {@link com.google.common.jimfs.HeapDisk HeapDisk}. A disk is a resizable factory and cache for
- * fixed size blocks of memory. These blocks are allocated to files as needed and returned to the
- * disk when a file is deleted or truncated. When cached free blocks are available, those blocks
- * are allocated to files first. If more blocks are needed, they are created.
+ * {@link RegularFile RegularFile} makes use of a singleton {@link com.google.common.jimfs.HeapDisk
+ * HeapDisk}. A disk is a resizable factory and cache for fixed size blocks of memory. These blocks
+ * are allocated to files as needed and returned to the disk when a file is deleted or truncated.
+ * When cached free blocks are available, those blocks are allocated to files first. If more blocks
+ * are needed, they are created.
  *
  * <h3>Linking</h3>
  *
- * When a file is mapped to a file name in a directory table, it is <i>linked</i>. Each type of
- * file has different rules governing how it is linked.
+ * When a file is mapped to a file name in a directory table, it is <i>linked</i>. Each type of file
+ * has different rules governing how it is linked.
  *
  * <ul>
- *   <li>Directory - A directory has two or more links to it. The first is the link from
- *   its parent directory to it. This link is the name of the directory. The second is the
- *   <i>self</i> link (".") which links the directory to itself. The directory may also have any
- *   number of additional <i>parent</i> links ("..") from child directories back to it.</li>
+ *   <li>Directory - A directory has two or more links to it. The first is the link from its parent
+ *       directory to it. This link is the name of the directory. The second is the <i>self</i> link
+ *       (".") which links the directory to itself. The directory may also have any number of
+ *       additional <i>parent</i> links ("..") from child directories back to it.
  *   <li>Regular file - A regular file has one link from its parent directory by default. However,
- *   regular files are also allowed to have any number of additional user-created hard links, from
- *   the same directory with different names and/or from other directories with any names.</li>
- *   <li>Symbolic link - A symbolic link can only have one link, from its parent directory.</li>
+ *       regular files are also allowed to have any number of additional user-created hard links,
+ *       from the same directory with different names and/or from other directories with any names.
+ *   <li>Symbolic link - A symbolic link can only have one link, from its parent directory.
  * </ul>
  *
  * <h3>Thread safety</h3>
@@ -202,16 +198,12 @@ final class JimfsFileSystem extends FileSystem {
     return provider;
   }
 
-  /**
-   * Returns the URI for this file system.
-   */
+  /** Returns the URI for this file system. */
   public URI getUri() {
     return uri;
   }
 
-  /**
-   * Returns the default view for this file system.
-   */
+  /** Returns the default view for this file system. */
   public FileSystemView getDefaultView() {
     return defaultView;
   }
@@ -231,24 +223,18 @@ final class JimfsFileSystem extends FileSystem {
     return (ImmutableSortedSet<Path>) (ImmutableSortedSet<?>) builder.build();
   }
 
-  /**
-   * Returns the working directory path for this file system.
-   */
+  /** Returns the working directory path for this file system. */
   public JimfsPath getWorkingDirectory() {
     return defaultView.getWorkingDirectoryPath();
   }
 
-  /**
-   * Returns the path service for this file system.
-   */
+  /** Returns the path service for this file system. */
   @VisibleForTesting
   PathService getPathService() {
     return pathService;
   }
 
-  /**
-   * Returns the file store for this file system.
-   */
+  /** Returns the file store for this file system. */
   public JimfsFileStore getFileStore() {
     return fileStore;
   }
@@ -270,17 +256,13 @@ final class JimfsFileSystem extends FileSystem {
     return pathService.parsePath(first, more);
   }
 
-  /**
-   * Gets the URI of the given path in this file system.
-   */
+  /** Gets the URI of the given path in this file system. */
   public URI toUri(JimfsPath path) {
     fileStore.state().checkOpen();
     return pathService.toUri(uri, path.toAbsolutePath());
   }
 
-  /**
-   * Converts the given URI into a path in this file system.
-   */
+  /** Converts the given URI into a path in this file system. */
   public JimfsPath toPath(URI uri) {
     fileStore.state().checkOpen();
     return pathService.fromUri(uri);

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystemProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystemProvider.java
@@ -23,7 +23,6 @@ import static com.google.common.jimfs.Jimfs.URI_SCHEME;
 import static java.nio.file.StandardOpenOption.APPEND;
 
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -49,14 +48,13 @@ import java.nio.file.spi.FileSystemProvider;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-
 import javax.annotation.Nullable;
 
 /**
  * {@link FileSystemProvider} implementation for Jimfs. This provider implements the actual file
- * system operations but does not handle creation, caching or lookup of file systems. See
- * {@link SystemJimfsFileSystemProvider}, which is the {@code META-INF/services/} entry for Jimfs,
- * for those operations.
+ * system operations but does not handle creation, caching or lookup of file systems. See {@link
+ * SystemJimfsFileSystemProvider}, which is the {@code META-INF/services/} entry for Jimfs, for
+ * those operations.
  *
  * @author Colin Decker
  */
@@ -73,9 +71,7 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
     }
   }
 
-  /**
-   * Returns the singleton instance of this provider.
-   */
+  /** Returns the singleton instance of this provider. */
   static JimfsFileSystemProvider instance() {
     return INSTANCE;
   }
@@ -131,16 +127,12 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
         "path " + path + " is not associated with a Jimfs file system");
   }
 
-  /**
-   * Gets the file system for the given path.
-   */
+  /** Gets the file system for the given path. */
   private static JimfsFileSystem getFileSystem(Path path) {
     return (JimfsFileSystem) checkPath(path).getFileSystem();
   }
 
-  /**
-   * Returns the default file system view for the given path.
-   */
+  /** Returns the default file system view for the given path. */
   private static FileSystemView getDefaultView(JimfsPath path) {
     return getFileSystem(path).getDefaultView();
   }
@@ -311,12 +303,10 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
     JimfsPath checkedPath = checkPath(path);
     FileSystemView view = getDefaultView(checkedPath);
     if (getFileStore(path).supportsFileAttributeView("dos")) {
-      return view
-          .readAttributes(checkedPath, DosFileAttributes.class, Options.NOFOLLOW_LINKS)
+      return view.readAttributes(checkedPath, DosFileAttributes.class, Options.NOFOLLOW_LINKS)
           .isHidden();
     }
-    return path.getNameCount() > 0
-        && path.getFileName().toString().startsWith(".");
+    return path.getNameCount() > 0 && path.getFileName().toString().startsWith(".");
   }
 
   @Override

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystems.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystems.java
@@ -39,8 +39,8 @@ final class JimfsFileSystems {
       };
 
   /**
-   * Returns a {@code Runnable} that will remove the file system with the given {@code URI} from
-   * the system provider's cache when called.
+   * Returns a {@code Runnable} that will remove the file system with the given {@code URI} from the
+   * system provider's cache when called.
    */
   private static Runnable removeFileSystemRunnable(URI uri) {
     if (Jimfs.systemProvider == null) {
@@ -81,9 +81,7 @@ final class JimfsFileSystems {
     return fileSystem;
   }
 
-  /**
-   * Creates the file store for the file system.
-   */
+  /** Creates the file store for the file system. */
   private static JimfsFileStore createFileStore(
       Configuration config, PathService pathService, FileSystemState state) {
     AttributeService attributeService = new AttributeService(config);
@@ -112,9 +110,7 @@ final class JimfsFileSystems {
         new FileTree(roots), fileFactory, disk, attributeService, config.supportedFeatures, state);
   }
 
-  /**
-   * Creates the default view of the file system using the given working directory.
-   */
+  /** Creates the default view of the file system using the given working directory. */
   private static FileSystemView createDefaultView(
       Configuration config, JimfsFileStore fileStore, PathService pathService) throws IOException {
     JimfsPath workingDirPath = pathService.parsePath(config.workingDirectory);

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsInputStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsInputStream.java
@@ -21,10 +21,8 @@ import static com.google.common.base.Preconditions.checkPositionIndexes;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
-
 import java.io.IOException;
 import java.io.InputStream;
-
 import javax.annotation.concurrent.GuardedBy;
 
 /**

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsOutputStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsOutputStream.java
@@ -20,10 +20,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import java.io.IOException;
 import java.io.OutputStream;
-
 import javax.annotation.concurrent.GuardedBy;
 
 /**

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsPath.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsPath.java
@@ -61,17 +61,13 @@ final class JimfsPath implements Path {
     this.names = ImmutableList.copyOf(names);
   }
 
-  /**
-   * Returns the root name, or null if there is no root.
-   */
+  /** Returns the root name, or null if there is no root. */
   @Nullable
   public Name root() {
     return root;
   }
 
-  /**
-   * Returns the list of name elements.
-   */
+  /** Returns the list of name elements. */
   public ImmutableList<Name> names() {
     return names;
   }
@@ -92,9 +88,7 @@ final class JimfsPath implements Path {
    * Returns whether or not this is the empty path, with no root and a single, empty string, name.
    */
   public boolean isEmptyPath() {
-    return root == null
-        && names.size() == 1
-        && names.get(0).toString().isEmpty();
+    return root == null && names.size() == 1 && names.get(0).toString().isEmpty();
   }
 
   @Override
@@ -165,9 +159,7 @@ final class JimfsPath implements Path {
     return pathService.createRelativePath(names.subList(beginIndex, endIndex));
   }
 
-  /**
-   * Returns true if list starts with all elements of other in the same order.
-   */
+  /** Returns true if list starts with all elements of other in the same order. */
   private static boolean startsWith(List<?> list, List<?> other) {
     return list.size() >= other.size() && list.subList(0, other.size()).equals(other);
   }
@@ -257,19 +249,13 @@ final class JimfsPath implements Path {
     return normal;
   }
 
-  /**
-   * Resolves the given name against this path. The name is assumed not to be a root name.
-   */
+  /** Resolves the given name against this path. The name is assumed not to be a root name. */
   JimfsPath resolve(Name name) {
     if (name.toString().isEmpty()) {
       return this;
     }
     return pathService.createPathInternal(
-        root,
-        ImmutableList.<Name>builder()
-            .addAll(names)
-            .add(name)
-            .build());
+        root, ImmutableList.<Name>builder().addAll(names).add(name).build());
   }
 
   @Override
@@ -286,11 +272,7 @@ final class JimfsPath implements Path {
       return this;
     }
     return pathService.createPath(
-        root,
-        ImmutableList.<Name>builder()
-            .addAll(names)
-            .addAll(otherPath.names)
-            .build());
+        root, ImmutableList.<Name>builder().addAll(names).addAll(otherPath.names).build());
   }
 
   @Override

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsSecureDirectoryStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsSecureDirectoryStream.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.ClosedDirectoryStreamException;
@@ -36,7 +35,6 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileAttributeView;
 import java.util.Iterator;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 
 /**
@@ -116,9 +114,7 @@ final class JimfsSecureDirectoryStream implements SecureDirectoryStream<Path> {
     }
   }
 
-  /**
-   * A stream filter that always returns true.
-   */
+  /** A stream filter that always returns true. */
   public static final Filter<Object> ALWAYS_TRUE_FILTER =
       new Filter<Object>() {
         @Override
@@ -205,10 +201,7 @@ final class JimfsSecureDirectoryStream implements SecureDirectoryStream<Path> {
           @Override
           public File lookup() throws IOException {
             checkOpen(); // per the spec, must check that the stream is open for each view operation
-            return view
-                .lookUpWithLock(checkedPath, optionsSet)
-                .requireExists(checkedPath)
-                .file();
+            return view.lookUpWithLock(checkedPath, optionsSet).requireExists(checkedPath).file();
           }
         },
         type);

--- a/jimfs/src/main/java/com/google/common/jimfs/Name.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Name.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.Ordering;
-
 import javax.annotation.Nullable;
 
 /**
@@ -49,9 +48,7 @@ final class Name {
   /** The name to use for a link from a directory to its parent directory. */
   public static final Name PARENT = new Name("..", "..");
 
-  /**
-   * Creates a new name with no normalization done on the given string.
-   */
+  /** Creates a new name with no normalization done on the given string. */
   @VisibleForTesting
   static Name simple(String name) {
     switch (name) {
@@ -98,16 +95,12 @@ final class Name {
     return display;
   }
 
-  /**
-   * Returns an ordering that orders names by their display representation.
-   */
+  /** Returns an ordering that orders names by their display representation. */
   public static Ordering<Name> displayOrdering() {
     return DISPLAY_ORDERING;
   }
 
-  /**
-   * Returns an ordering that orders names by their canonical representation.
-   */
+  /** Returns an ordering that orders names by their canonical representation. */
   public static Ordering<Name> canonicalOrdering() {
     return CANONICAL_ORDERING;
   }

--- a/jimfs/src/main/java/com/google/common/jimfs/Options.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Options.java
@@ -34,8 +34,8 @@ import java.util.Collection;
 import java.util.Set;
 
 /**
- * Utility methods for normalizing user-provided options arrays and sets to canonical immutable
- * sets of options.
+ * Utility methods for normalizing user-provided options arrays and sets to canonical immutable sets
+ * of options.
  *
  * @author Colin Decker
  */
@@ -43,15 +43,11 @@ final class Options {
 
   private Options() {}
 
-  /**
-   * Immutable set containing LinkOption.NOFOLLOW_LINKS.
-   */
+  /** Immutable set containing LinkOption.NOFOLLOW_LINKS. */
   public static final ImmutableSet<LinkOption> NOFOLLOW_LINKS =
       ImmutableSet.of(LinkOption.NOFOLLOW_LINKS);
 
-  /**
-   * Immutable empty LinkOption set.
-   */
+  /** Immutable empty LinkOption set. */
   public static final ImmutableSet<LinkOption> FOLLOW_LINKS = ImmutableSet.of();
 
   private static final ImmutableSet<OpenOption> DEFAULT_READ = ImmutableSet.<OpenOption>of(READ);
@@ -62,16 +58,12 @@ final class Options {
   private static final ImmutableSet<OpenOption> DEFAULT_WRITE =
       ImmutableSet.<OpenOption>of(WRITE, CREATE, TRUNCATE_EXISTING);
 
-  /**
-   * Returns an immutable set of link options.
-   */
+  /** Returns an immutable set of link options. */
   public static ImmutableSet<LinkOption> getLinkOptions(LinkOption... options) {
     return options.length == 0 ? FOLLOW_LINKS : NOFOLLOW_LINKS;
   }
 
-  /**
-   * Returns an immutable set of open options for opening a new file channel.
-   */
+  /** Returns an immutable set of open options for opening a new file channel. */
   public static ImmutableSet<OpenOption> getOptionsForChannel(Set<? extends OpenOption> options) {
     if (options.isEmpty()) {
       return DEFAULT_READ;
@@ -99,9 +91,7 @@ final class Options {
     return addWrite(options);
   }
 
-  /**
-   * Returns an immutable set of open options for opening a new input stream.
-   */
+  /** Returns an immutable set of open options for opening a new input stream. */
   @SuppressWarnings("unchecked") // safe covariant cast
   public static ImmutableSet<OpenOption> getOptionsForInputStream(OpenOption... options) {
     boolean nofollowLinks = false;
@@ -120,9 +110,7 @@ final class Options {
         (ImmutableSet<?>) (nofollowLinks ? NOFOLLOW_LINKS : FOLLOW_LINKS);
   }
 
-  /**
-   * Returns an immutable set of open options for opening a new output stream.
-   */
+  /** Returns an immutable set of open options for opening a new output stream. */
   public static ImmutableSet<OpenOption> getOptionsForOutputStream(OpenOption... options) {
     if (options.length == 0) {
       return DEFAULT_WRITE;
@@ -145,16 +133,12 @@ final class Options {
         : ImmutableSet.<OpenOption>builder().add(WRITE).addAll(options).build();
   }
 
-  /**
-   * Returns an immutable set of the given options for a move.
-   */
+  /** Returns an immutable set of the given options for a move. */
   public static ImmutableSet<CopyOption> getMoveOptions(CopyOption... options) {
     return ImmutableSet.copyOf(Lists.asList(LinkOption.NOFOLLOW_LINKS, options));
   }
 
-  /**
-   * Returns an immutable set of the given options for a copy.
-   */
+  /** Returns an immutable set of the given options for a copy. */
   public static ImmutableSet<CopyOption> getCopyOptions(CopyOption... options) {
     ImmutableSet<CopyOption> result = ImmutableSet.copyOf(options);
     if (result.contains(ATOMIC_MOVE)) {

--- a/jimfs/src/main/java/com/google/common/jimfs/OwnerAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/OwnerAttributeProvider.java
@@ -21,13 +21,11 @@ import static com.google.common.jimfs.UserLookupService.createUserPrincipal;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -100,9 +98,7 @@ final class OwnerAttributeProvider extends AttributeProvider {
     return new View(lookup);
   }
 
-  /**
-   * Implementation of {@link FileOwnerAttributeView}.
-   */
+  /** Implementation of {@link FileOwnerAttributeView}. */
   private static final class View extends AbstractAttributeView implements FileOwnerAttributeView {
 
     public View(FileLookup lookup) {

--- a/jimfs/src/main/java/com/google/common/jimfs/PathMatchers.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathMatchers.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
-
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -39,11 +38,11 @@ final class PathMatchers {
   private PathMatchers() {}
 
   /**
-   * Gets a {@link PathMatcher} for the given syntax and pattern as specified by
-   * {@link FileSystem#getPathMatcher}. The {@code separators} string contains the path name
-   * element separators (one character each) recognized by the file system. For a glob-syntax path
-   * matcher, any of the given separators will be recognized as a separator in the pattern, and any
-   * of them will be matched as a separator when checking a path.
+   * Gets a {@link PathMatcher} for the given syntax and pattern as specified by {@link
+   * FileSystem#getPathMatcher}. The {@code separators} string contains the path name element
+   * separators (one character each) recognized by the file system. For a glob-syntax path matcher,
+   * any of the given separators will be recognized as a separator in the pattern, and any of them
+   * will be matched as a separator when checking a path.
    */
   // TODO(cgdecker): Should I be just canonicalizing separators rather than matching any separator?
   // Perhaps so, assuming Path always canonicalizes its separators

--- a/jimfs/src/main/java/com/google/common/jimfs/PathNormalization.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathNormalization.java
@@ -18,25 +18,21 @@ package com.google.common.jimfs;
 
 import com.google.common.base.Ascii;
 import com.google.common.base.Function;
-
 import com.ibm.icu.lang.UCharacter;
-
 import java.text.Normalizer;
 import java.util.regex.Pattern;
 
 /**
  * Normalizations that can be applied to names in paths. Includes Unicode normalizations and
- * normalizations for case insensitive paths. These normalizations can be set in
- * {@code Configuration.Builder} when creating a Jimfs file system instance and are automatically
- * applied to paths in the file system.
+ * normalizations for case insensitive paths. These normalizations can be set in {@code
+ * Configuration.Builder} when creating a Jimfs file system instance and are automatically applied
+ * to paths in the file system.
  *
  * @author Colin Decker
  */
 public enum PathNormalization implements Function<String, String> {
 
-  /**
-   * No normalization.
-   */
+  /** No normalization. */
   NONE(0) {
     @Override
     public String apply(String string) {
@@ -44,9 +40,7 @@ public enum PathNormalization implements Function<String, String> {
     }
   },
 
-  /**
-   * Unicode composed normalization (form {@linkplain java.text.Normalizer.Form#NFC NFC}).
-   */
+  /** Unicode composed normalization (form {@linkplain java.text.Normalizer.Form#NFC NFC}). */
   NFC(Pattern.CANON_EQ) {
     @Override
     public String apply(String string) {
@@ -54,16 +48,14 @@ public enum PathNormalization implements Function<String, String> {
     }
   },
 
-  /**
-   * Unicode decomposed normalization (form {@linkplain java.text.Normalizer.Form#NFD NFD}).
-   */
+  /** Unicode decomposed normalization (form {@linkplain java.text.Normalizer.Form#NFD NFD}). */
   NFD(Pattern.CANON_EQ) {
     @Override
     public String apply(String string) {
       return Normalizer.normalize(string, Normalizer.Form.NFD);
     }
   },
-    
+
   /*
    * Some notes on case folding/case insensitivity of file systems:
    *
@@ -76,9 +68,7 @@ public enum PathNormalization implements Function<String, String> {
    * copy of Windows.
    */
 
-  /**
-   * Unicode case folding for case insensitive paths. Requires ICU4J on the classpath.
-   */
+  /** Unicode case folding for case insensitive paths. Requires ICU4J on the classpath. */
   CASE_FOLD_UNICODE(Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE) {
     @Override
     public String apply(String string) {
@@ -95,9 +85,7 @@ public enum PathNormalization implements Function<String, String> {
     }
   },
 
-  /**
-   * ASCII case folding for simple case insensitive paths.
-   */
+  /** ASCII case folding for simple case insensitive paths. */
   CASE_FOLD_ASCII(Pattern.CASE_INSENSITIVE) {
     @Override
     public String apply(String string) {
@@ -111,9 +99,7 @@ public enum PathNormalization implements Function<String, String> {
     this.patternFlags = patternFlags;
   }
 
-  /**
-   * Applies this normalization to the given string, returning the normalized result.
-   */
+  /** Applies this normalization to the given string, returning the normalized result. */
   @Override
   public abstract String apply(String string);
 
@@ -126,8 +112,7 @@ public enum PathNormalization implements Function<String, String> {
   }
 
   /**
-   * Applies the given normalizations to the given string in order, returning the normalized
-   * result.
+   * Applies the given normalizations to the given string in order, returning the normalized result.
    */
   public static String normalize(String string, Iterable<PathNormalization> normalizations) {
     String result = string;
@@ -137,9 +122,7 @@ public enum PathNormalization implements Function<String, String> {
     return result;
   }
 
-  /**
-   * Compiles a regex pattern using flags based on the given normalizations.
-   */
+  /** Compiles a regex pattern using flags based on the given normalizations. */
   public static Pattern compilePattern(String regex, Iterable<PathNormalization> normalizations) {
     int flags = 0;
     for (PathNormalization normalization : normalizations) {

--- a/jimfs/src/main/java/com/google/common/jimfs/PathService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathService.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -39,7 +38,6 @@ import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-
 import javax.annotation.Nullable;
 
 /**
@@ -93,32 +91,24 @@ final class PathService implements Comparator<JimfsPath> {
         equalityUsesCanonicalForm ? CANONICAL_NAMES_ORDERING : DISPLAY_NAMES_ORDERING;
   }
 
-  /**
-   * Sets the file system to use for created paths.
-   */
+  /** Sets the file system to use for created paths. */
   public void setFileSystem(FileSystem fileSystem) {
     // allowed to not be JimfsFileSystem for testing purposes only
     checkState(this.fileSystem == null, "may not set fileSystem twice");
     this.fileSystem = checkNotNull(fileSystem);
   }
 
-  /**
-   * Returns the file system this service is for.
-   */
+  /** Returns the file system this service is for. */
   public FileSystem getFileSystem() {
     return fileSystem;
   }
 
-  /**
-   * Returns the default path separator.
-   */
+  /** Returns the default path separator. */
   public String getSeparator() {
     return type.getSeparator();
   }
 
-  /**
-   * Returns an empty path which has a single name, the empty string.
-   */
+  /** Returns an empty path which has a single name, the empty string. */
   public JimfsPath emptyPath() {
     JimfsPath result = emptyPath;
     if (result == null) {
@@ -130,9 +120,7 @@ final class PathService implements Comparator<JimfsPath> {
     return result;
   }
 
-  /**
-   * Returns the {@link Name} form of the given string.
-   */
+  /** Returns the {@link Name} form of the given string. */
   public Name name(String name) {
     switch (name) {
       case "":
@@ -148,9 +136,7 @@ final class PathService implements Comparator<JimfsPath> {
     }
   }
 
-  /**
-   * Returns the {@link Name} forms of the given strings.
-   */
+  /** Returns the {@link Name} forms of the given strings. */
   @VisibleForTesting
   List<Name> names(Iterable<String> names) {
     List<Name> result = new ArrayList<>();
@@ -160,30 +146,22 @@ final class PathService implements Comparator<JimfsPath> {
     return result;
   }
 
-  /**
-   * Returns a root path with the given name.
-   */
+  /** Returns a root path with the given name. */
   public JimfsPath createRoot(Name root) {
     return createPath(checkNotNull(root), ImmutableList.<Name>of());
   }
 
-  /**
-   * Returns a single filename path with the given name.
-   */
+  /** Returns a single filename path with the given name. */
   public JimfsPath createFileName(Name name) {
     return createPath(null, ImmutableList.of(name));
   }
 
-  /**
-   * Returns a relative path with the given names.
-   */
+  /** Returns a relative path with the given names. */
   public JimfsPath createRelativePath(Iterable<Name> names) {
     return createPath(null, ImmutableList.copyOf(names));
   }
 
-  /**
-   * Returns a path with the given root (or no root, if null) and the given names.
-   */
+  /** Returns a path with the given root (or no root, if null) and the given names. */
   public JimfsPath createPath(@Nullable Name root, Iterable<Name> names) {
     ImmutableList<Name> nameList = ImmutableList.copyOf(Iterables.filter(names, NOT_EMPTY));
     if (root == null && nameList.isEmpty()) {
@@ -194,16 +172,12 @@ final class PathService implements Comparator<JimfsPath> {
     return createPathInternal(root, nameList);
   }
 
-  /**
-   * Returns a path with the given root (or no root, if null) and the given names.
-   */
+  /** Returns a path with the given root (or no root, if null) and the given names. */
   protected final JimfsPath createPathInternal(@Nullable Name root, Iterable<Name> names) {
     return new JimfsPath(this, root, names);
   }
 
-  /**
-   * Parses the given strings as a path.
-   */
+  /** Parses the given strings as a path. */
   public JimfsPath parsePath(String first, String... more) {
     String joined = type.joiner().join(Iterables.filter(Lists.asList(first, more), NOT_EMPTY));
     return toPath(type.parsePath(joined));
@@ -215,9 +189,7 @@ final class PathService implements Comparator<JimfsPath> {
     return createPath(root, names);
   }
 
-  /**
-   * Returns the string form of the given path.
-   */
+  /** Returns the string form of the given path. */
   public String toString(JimfsPath path) {
     Name root = path.root();
     String rootString = root == null ? null : root.toString();
@@ -225,9 +197,7 @@ final class PathService implements Comparator<JimfsPath> {
     return type.toString(rootString, names);
   }
 
-  /**
-   * Creates a hash code for the given path.
-   */
+  /** Creates a hash code for the given path. */
   public int hash(JimfsPath path) {
     int hash = 31;
     hash = 31 * hash + getFileSystem().hashCode();
@@ -270,16 +240,14 @@ final class PathService implements Comparator<JimfsPath> {
     return type.toUri(fileSystemUri, root, names, Files.isDirectory(path, NOFOLLOW_LINKS));
   }
 
-  /**
-   * Converts the path of the given URI into a path for this file system.
-   */
+  /** Converts the path of the given URI into a path for this file system. */
   public JimfsPath fromUri(URI uri) {
     return toPath(type.fromUri(uri));
   }
 
   /**
-   * Returns a {@link PathMatcher} for the given syntax and pattern as specified by
-   * {@link FileSystem#getPathMatcher(String)}.
+   * Returns a {@link PathMatcher} for the given syntax and pattern as specified by {@link
+   * FileSystem#getPathMatcher(String)}.
    */
   public PathMatcher createPathMatcher(String syntaxAndPattern) {
     return PathMatchers.getPathMatcher(

--- a/jimfs/src/main/java/com/google/common/jimfs/PathType.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathType.java
@@ -22,12 +22,10 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.InvalidPathException;
 import java.util.Arrays;
-
 import javax.annotation.Nullable;
 
 /**
@@ -51,19 +49,19 @@ public abstract class PathType {
    * Returns a Windows-style path type. The canonical separator character is "\". "/" is also
    * treated as a separator when parsing paths.
    *
-   * <p>As much as possible, this implementation follows the information provided in
-   * <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx">
-   * this article</a>. Paths with drive-letter roots (e.g. "C:\") and paths with UNC roots (e.g.
+   * <p>As much as possible, this implementation follows the information provided in <a
+   * href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx">this
+   * article</a>. Paths with drive-letter roots (e.g. "C:\") and paths with UNC roots (e.g.
    * "\\host\share\") are supported.
    *
    * <p>Two Windows path features are not currently supported as they are too Windows-specific:
    *
    * <ul>
    *   <li>Relative paths containing a drive-letter root, for example "C:" or "C:foo\bar". Such
-   *   paths have a root component and optionally have names, but are <i>relative</i> paths,
-   *   relative to the working directory of the drive identified by the root.</li>
-   *   <li>Absolute paths with no root, for example "\foo\bar". Such paths are absolute paths on
-   *   the current drive.</li>
+   *       paths have a root component and optionally have names, but are <i>relative</i> paths,
+   *       relative to the working directory of the drive identified by the root.
+   *   <li>Absolute paths with no root, for example "\foo\bar". Such paths are absolute paths on the
+   *       current drive.
    * </ul>
    */
   public static PathType windows() {
@@ -117,9 +115,7 @@ public abstract class PathType {
     patternBuilder.append(separator);
   }
 
-  /**
-   * Returns whether or not this type of path allows multiple root directories.
-   */
+  /** Returns whether or not this type of path allows multiple root directories. */
   public final boolean allowsMultipleRoots() {
     return allowsMultipleRoots;
   }
@@ -140,23 +136,17 @@ public abstract class PathType {
     return otherSeparators;
   }
 
-  /**
-   * Returns the path joiner for this path type.
-   */
+  /** Returns the path joiner for this path type. */
   public final Joiner joiner() {
     return joiner;
   }
 
-  /**
-   * Returns the path splitter for this path type.
-   */
+  /** Returns the path splitter for this path type. */
   public final Splitter splitter() {
     return splitter;
   }
 
-  /**
-   * Returns an empty path.
-   */
+  /** Returns an empty path. */
   protected final ParseResult emptyPath() {
     return new ParseResult(null, ImmutableList.of(""));
   }
@@ -173,9 +163,7 @@ public abstract class PathType {
     return getClass().getSimpleName();
   }
 
-  /**
-   * Returns the string form of the given path.
-   */
+  /** Returns the string form of the given path. */
   public abstract String toString(@Nullable String root, Iterable<String> names);
 
   /**
@@ -215,16 +203,12 @@ public abstract class PathType {
     }
   }
 
-  /**
-   * Parses a path from the given URI.
-   */
+  /** Parses a path from the given URI. */
   public final ParseResult fromUri(URI uri) {
     return parseUriPath(uri.getPath());
   }
 
-  /**
-   * Simple result of parsing a path.
-   */
+  /** Simple result of parsing a path. */
   public static final class ParseResult {
 
     @Nullable private final String root;
@@ -235,31 +219,23 @@ public abstract class PathType {
       this.names = checkNotNull(names);
     }
 
-    /**
-     * Returns whether or not this result is an absolute path.
-     */
+    /** Returns whether or not this result is an absolute path. */
     public boolean isAbsolute() {
       return root != null;
     }
 
-    /**
-     * Returns whether or not this result represents a root path.
-     */
+    /** Returns whether or not this result represents a root path. */
     public boolean isRoot() {
       return root != null && Iterables.isEmpty(names);
     }
 
-    /**
-     * Returns the parsed root element, or null if there was no root.
-     */
+    /** Returns the parsed root element, or null if there was no root. */
     @Nullable
     public String root() {
       return root;
     }
 
-    /**
-     * Returns the parsed name elements.
-     */
+    /** Returns the parsed name elements. */
     public Iterable<String> names() {
       return names;
     }

--- a/jimfs/src/main/java/com/google/common/jimfs/PathURLConnection.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathURLConnection.java
@@ -24,7 +24,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/jimfs/src/main/java/com/google/common/jimfs/PollingWatchService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PollingWatchService.java
@@ -26,7 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
@@ -62,19 +61,15 @@ final class PollingWatchService extends AbstractWatchService {
   private final ScheduledExecutorService pollingService =
       Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY);
 
-  /**
-   * Map of keys to the most recent directory snapshot for each key.
-   */
+  /** Map of keys to the most recent directory snapshot for each key. */
   private final ConcurrentMap<Key, Snapshot> snapshots = new ConcurrentHashMap<>();
 
   private final FileSystemView view;
   private final PathService pathService;
   private final FileSystemState fileSystemState;
 
-  @VisibleForTesting
-  final long interval;
-  @VisibleForTesting
-  final TimeUnit timeUnit;
+  @VisibleForTesting final long interval;
+  @VisibleForTesting final TimeUnit timeUnit;
 
   private ScheduledFuture<?> pollingFuture;
 
@@ -160,8 +155,7 @@ final class PollingWatchService extends AbstractWatchService {
   }
 
   private void startPolling() {
-    pollingFuture =
-        pollingService.scheduleAtFixedRate(pollingTask, interval, interval, timeUnit);
+    pollingFuture = pollingService.scheduleAtFixedRate(pollingTask, interval, interval, timeUnit);
   }
 
   private void stopPolling() {
@@ -200,14 +194,10 @@ final class PollingWatchService extends AbstractWatchService {
     return new Snapshot(view.snapshotModifiedTimes(path));
   }
 
-  /**
-   * Snapshot of the state of a directory at a particular moment.
-   */
+  /** Snapshot of the state of a directory at a particular moment. */
   private final class Snapshot {
 
-    /**
-     * Maps directory entry names to last modified times.
-     */
+    /** Maps directory entry names to last modified times. */
     private final ImmutableMap<Name, Long> modifiedTimes;
 
     Snapshot(Map<Name, Long> modifiedTimes) {

--- a/jimfs/src/main/java/com/google/common/jimfs/PosixAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PosixAttributeProvider.java
@@ -22,7 +22,6 @@ import static com.google.common.jimfs.UserLookupService.createGroupPrincipal;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-
 import java.io.IOException;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.FileAttributeView;
@@ -36,7 +35,6 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 
 /**
@@ -81,9 +79,12 @@ final class PosixAttributeProvider extends AttributeProvider {
         group = createGroupPrincipal((String) userProvidedGroup);
       } else {
         throw new IllegalArgumentException(
-            "invalid type " + userProvidedGroup.getClass().getName()
+            "invalid type "
+                + userProvidedGroup.getClass().getName()
                 + " for attribute 'posix:group': should be one of "
-                + String.class + " or " + GroupPrincipal.class);
+                + String.class
+                + " or "
+                + GroupPrincipal.class);
       }
     }
 
@@ -99,9 +100,12 @@ final class PosixAttributeProvider extends AttributeProvider {
         permissions = toPermissions((Set<?>) userProvidedPermissions);
       } else {
         throw new IllegalArgumentException(
-            "invalid type " + userProvidedPermissions.getClass().getName()
+            "invalid type "
+                + userProvidedPermissions.getClass().getName()
                 + " for attribute 'posix:permissions': should be one of "
-                + String.class + " or " + Set.class);
+                + String.class
+                + " or "
+                + Set.class);
       }
     }
 
@@ -182,9 +186,7 @@ final class PosixAttributeProvider extends AttributeProvider {
     return new Attributes(file);
   }
 
-  /**
-   * Implementation of {@link PosixFileAttributeView}.
-   */
+  /** Implementation of {@link PosixFileAttributeView}. */
   private static class View extends AbstractAttributeView implements PosixFileAttributeView {
 
     private final BasicFileAttributeView basicView;
@@ -234,9 +236,7 @@ final class PosixAttributeProvider extends AttributeProvider {
     }
   }
 
-  /**
-   * Implementation of {@link PosixFileAttributes}.
-   */
+  /** Implementation of {@link PosixFileAttributes}. */
   static class Attributes extends BasicAttributeProvider.Attributes implements PosixFileAttributes {
 
     private final UserPrincipal owner;

--- a/jimfs/src/main/java/com/google/common/jimfs/RegularFile.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/RegularFile.java
@@ -23,7 +23,6 @@ import static com.google.common.jimfs.Util.nextPowerOf2;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.UnsignedBytes;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -53,9 +52,7 @@ final class RegularFile extends File {
 
   private long size;
 
-  /**
-   * Creates a new regular file with the given ID and using the given disk.
-   */
+  /** Creates a new regular file with the given ID and using the given disk. */
   public static RegularFile create(int id, HeapDisk disk) {
     return new RegularFile(id, disk, new byte[32][], 0, 0);
   }
@@ -73,16 +70,12 @@ final class RegularFile extends File {
   private int openCount = 0;
   private boolean deleted = false;
 
-  /**
-   * Returns the read lock for this file.
-   */
+  /** Returns the read lock for this file. */
   public Lock readLock() {
     return lock.readLock();
   }
 
-  /**
-   * Returns the write lock for this file.
-   */
+  /** Returns the write lock for this file. */
   public Lock writeLock() {
     return lock.writeLock();
   }
@@ -95,16 +88,12 @@ final class RegularFile extends File {
     }
   }
 
-  /**
-   * Returns the number of blocks this file contains.
-   */
+  /** Returns the number of blocks this file contains. */
   int blockCount() {
     return blockCount;
   }
 
-  /**
-   * Copies the last {@code count} blocks from this file to the end of the given target file.
-   */
+  /** Copies the last {@code count} blocks from this file to the end of the given target file. */
   void copyBlocksTo(RegularFile target, int count) {
     int start = blockCount - count;
     int targetEnd = target.blockCount + count;
@@ -114,33 +103,25 @@ final class RegularFile extends File {
     target.blockCount = targetEnd;
   }
 
-  /**
-   * Transfers the last {@code count} blocks from this file to the end of the given target file.
-   */
+  /** Transfers the last {@code count} blocks from this file to the end of the given target file. */
   void transferBlocksTo(RegularFile target, int count) {
     copyBlocksTo(target, count);
     truncateBlocks(blockCount - count);
   }
 
-  /**
-   * Truncates the blocks of this file to the given block count.
-   */
+  /** Truncates the blocks of this file to the given block count. */
   void truncateBlocks(int count) {
     clear(blocks, count, blockCount - count);
     blockCount = count;
   }
 
-  /**
-   * Adds the given block to the end of this file.
-   */
+  /** Adds the given block to the end of this file. */
   void addBlock(byte[] block) {
     expandIfNecessary(blockCount + 1);
     blocks[blockCount++] = block;
   }
 
-  /**
-   * Gets the block at the given index in this file.
-   */
+  /** Gets the block at the given index in this file. */
   @VisibleForTesting
   byte[] getBlock(int index) {
     return blocks[index];
@@ -149,8 +130,8 @@ final class RegularFile extends File {
   // end of lower-level methods dealing with the blocks array
 
   /**
-   * Gets the current size of this file in bytes. Does not do locking, so should only be called
-   * when holding a lock.
+   * Gets the current size of this file in bytes. Does not do locking, so should only be called when
+   * holding a lock.
    */
   public long sizeWithoutLocking() {
     return size;
@@ -207,8 +188,8 @@ final class RegularFile extends File {
   }
 
   /**
-   * Marks this file as deleted. If there are no streams or channels open to the file, its
-   * contents are deleted if necessary.
+   * Marks this file as deleted. If there are no streams or channels open to the file, its contents
+   * are deleted if necessary.
    */
   @Override
   public synchronized void deleted() {
@@ -231,10 +212,10 @@ final class RegularFile extends File {
 
   /**
    * Truncates this file to the given {@code size}. If the given size is less than the current size
-   * of this file, the size of the file is reduced to the given size and any bytes beyond that
-   * size are lost. If the given size is greater than the current size of the file, this method
-   * does nothing. Returns {@code true} if this file was modified by the call (its size changed)
-   * and {@code false} otherwise.
+   * of this file, the size of the file is reduced to the given size and any bytes beyond that size
+   * are lost. If the given size is greater than the current size of the file, this method does
+   * nothing. Returns {@code true} if this file was modified by the call (its size changed) and
+   * {@code false} otherwise.
    */
   public boolean truncate(long size) {
     if (size >= this.size) {
@@ -253,9 +234,7 @@ final class RegularFile extends File {
     return true;
   }
 
-  /**
-   * Prepares for a write of len bytes starting at position pos.
-   */
+  /** Prepares for a write of len bytes starting at position pos. */
   private void prepareForWrite(long pos, long len) throws IOException {
     long end = pos + len;
 
@@ -289,9 +268,9 @@ final class RegularFile extends File {
   }
 
   /**
-   * Writes the given byte to this file at position {@code pos}. {@code pos} may be greater than
-   * the current size of this file, in which case this file is resized and all bytes between the
-   * current size and {@code pos} are set to 0. Returns the number of bytes written.
+   * Writes the given byte to this file at position {@code pos}. {@code pos} may be greater than the
+   * current size of this file, in which case this file is resized and all bytes between the current
+   * size and {@code pos} are set to 0. Returns the number of bytes written.
    *
    * @throws IOException if the file needs more blocks but the disk is full
    */
@@ -312,8 +291,8 @@ final class RegularFile extends File {
   /**
    * Writes {@code len} bytes starting at offset {@code off} in the given byte array to this file
    * starting at position {@code pos}. {@code pos} may be greater than the current size of this
-   * file, in which case this file is resized and all bytes between the current size and {@code
-   * pos} are set to 0. Returns the number of bytes written.
+   * file, in which case this file is resized and all bytes between the current size and {@code pos}
+   * are set to 0. Returns the number of bytes written.
    *
    * @throws IOException if the file needs more blocks but the disk is full
    */
@@ -352,9 +331,9 @@ final class RegularFile extends File {
 
   /**
    * Writes all available bytes from buffer {@code buf} to this file starting at position {@code
-   * pos}. {@code pos} may be greater than the current size of this file, in which case this file
-   * is resized and all bytes between the current size and {@code pos} are set to 0. Returns the
-   * number of bytes written.
+   * pos}. {@code pos} may be greater than the current size of this file, in which case this file is
+   * resized and all bytes between the current size and {@code pos} are set to 0. Returns the number
+   * of bytes written.
    *
    * @throws IOException if the file needs more blocks but the disk is full
    */
@@ -388,10 +367,10 @@ final class RegularFile extends File {
   }
 
   /**
-   * Writes all available bytes from each buffer in {@code bufs}, in order, to this file starting
-   * at position {@code pos}. {@code pos} may be greater than the current size of this file, in
-   * which case this file is resized and all bytes between the current size and {@code pos} are set
-   * to 0. Returns the number of bytes written.
+   * Writes all available bytes from each buffer in {@code bufs}, in order, to this file starting at
+   * position {@code pos}. {@code pos} may be greater than the current size of this file, in which
+   * case this file is resized and all bytes between the current size and {@code pos} are set to 0.
+   * Returns the number of bytes written.
    *
    * @throws IOException if the file needs more blocks but the disk is full
    */
@@ -572,10 +551,10 @@ final class RegularFile extends File {
 
   /**
    * Transfers up to {@code count} bytes to the given channel starting at position {@code pos} in
-   * this file. Returns the number of bytes transferred, possibly 0. Note that unlike all other
-   * read methods in this class, this method does not return -1 if {@code pos} is greater than or
-   * equal to the current size. This for consistency with {@link FileChannel#transferTo}, which
-   * this method is primarily intended as an implementation of.
+   * this file. Returns the number of bytes transferred, possibly 0. Note that unlike all other read
+   * methods in this class, this method does not return -1 if {@code pos} is greater than or equal
+   * to the current size. This for consistency with {@link FileChannel#transferTo}, which this
+   * method is primarily intended as an implementation of.
    */
   public long transferTo(long pos, long count, WritableByteChannel dest) throws IOException {
     long bytesToRead = bytesToRead(pos, count);
@@ -608,9 +587,7 @@ final class RegularFile extends File {
     return Math.max(bytesToRead, 0); // don't return -1 for this method
   }
 
-  /**
-   * Gets the block at the given index, expanding to create the block if necessary.
-   */
+  /** Gets the block at the given index, expanding to create the block if necessary. */
   private byte[] blockForWrite(int index) throws IOException {
     if (index >= blockCount) {
       int additionalBlocksNeeded = index - blockCount + 1;
@@ -648,25 +625,19 @@ final class RegularFile extends File {
     return Math.min(available, max);
   }
 
-  /**
-   * Zeroes len bytes in the given block starting at the given offset. Returns len.
-   */
+  /** Zeroes len bytes in the given block starting at the given offset. Returns len. */
   private static int zero(byte[] block, int offset, int len) {
     Util.zero(block, offset, len);
     return len;
   }
 
-  /**
-   * Puts the given slice of the given array at the given offset in the given block.
-   */
+  /** Puts the given slice of the given array at the given offset in the given block. */
   private static int put(byte[] block, int offset, byte[] b, int off, int len) {
     System.arraycopy(b, off, block, offset, len);
     return len;
   }
 
-  /**
-   * Puts the contents of the given byte buffer at the given offset in the given block.
-   */
+  /** Puts the contents of the given byte buffer at the given offset in the given block. */
   private static int put(byte[] block, int offset, ByteBuffer buf) {
     int len = Math.min(block.length - offset, buf.remaining());
     buf.get(block, offset, len);
@@ -682,9 +653,7 @@ final class RegularFile extends File {
     return len;
   }
 
-  /**
-   * Reads len bytes starting at the given offset in the given block into the given byte buffer.
-   */
+  /** Reads len bytes starting at the given offset in the given block into the given byte buffer. */
   private static int get(byte[] block, int offset, ByteBuffer buf, int len) {
     buf.put(block, offset, len);
     return len;

--- a/jimfs/src/main/java/com/google/common/jimfs/StandardAttributeProviders.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/StandardAttributeProviders.java
@@ -17,7 +17,6 @@
 package com.google.common.jimfs;
 
 import com.google.common.collect.ImmutableMap;
-
 import javax.annotation.Nullable;
 
 /**
@@ -41,8 +40,8 @@ final class StandardAttributeProviders {
           .build();
 
   /**
-   * Returns the attribute provider for the given view, or {@code null} if the given view is not
-   * one of the attribute views this supports.
+   * Returns the attribute provider for the given view, or {@code null} if the given view is not one
+   * of the attribute views this supports.
    */
   @Nullable
   public static AttributeProvider get(String view) {

--- a/jimfs/src/main/java/com/google/common/jimfs/SymbolicLink.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/SymbolicLink.java
@@ -27,9 +27,7 @@ final class SymbolicLink extends File {
 
   private final JimfsPath target;
 
-  /**
-   * Creates a new symbolic link with the given ID and target.
-   */
+  /** Creates a new symbolic link with the given ID and target. */
   public static SymbolicLink create(int id, JimfsPath target) {
     return new SymbolicLink(id, target);
   }
@@ -39,9 +37,7 @@ final class SymbolicLink extends File {
     this.target = checkNotNull(target);
   }
 
-  /**
-   * Returns the target path of this symbolic link.
-   */
+  /** Returns the target path of this symbolic link. */
   JimfsPath target() {
     return target;
   }

--- a/jimfs/src/main/java/com/google/common/jimfs/SystemJimfsFileSystemProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/SystemJimfsFileSystemProvider.java
@@ -22,7 +22,6 @@ import static com.google.common.jimfs.Jimfs.URI_SCHEME;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.MapMaker;
-
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -64,8 +63,8 @@ import java.util.concurrent.ConcurrentMap;
 public final class SystemJimfsFileSystemProvider extends FileSystemProvider {
 
   /**
-   * Env map key that maps to the already-created {@code FileSystem} instance in
-   * {@code newFileSystem}.
+   * Env map key that maps to the already-created {@code FileSystem} instance in {@code
+   * newFileSystem}.
    */
   static final String FILE_SYSTEM_KEY = "fileSystem";
 
@@ -90,9 +89,7 @@ public final class SystemJimfsFileSystemProvider extends FileSystemProvider {
   private static final ConcurrentMap<URI, FileSystem> fileSystems =
       new MapMaker().weakValues().makeMap();
 
-  /**
-   * @deprecated Not intended to be called directly; this class is only for use by Java itself.
-   */
+  /** @deprecated Not intended to be called directly; this class is only for use by Java itself. */
   @Deprecated
   public SystemJimfsFileSystemProvider() {} // a public, no-arg constructor is required
 
@@ -113,7 +110,9 @@ public final class SystemJimfsFileSystemProvider extends FileSystemProvider {
     checkArgument(
         env.get(FILE_SYSTEM_KEY) instanceof FileSystem,
         "env map (%s) must contain key '%s' mapped to an instance of %s",
-        env, FILE_SYSTEM_KEY, FileSystem.class);
+        env,
+        FILE_SYSTEM_KEY,
+        FileSystem.class);
 
     FileSystem fileSystem = (FileSystem) env.get(FILE_SYSTEM_KEY);
     if (fileSystems.putIfAbsent(uri, fileSystem) != null) {
@@ -155,9 +154,7 @@ public final class SystemJimfsFileSystemProvider extends FileSystemProvider {
         && isNullOrEmpty(uri.getFragment());
   }
 
-  /**
-   * Returns the given URI with any path, query or fragment stripped off.
-   */
+  /** Returns the given URI with any path, query or fragment stripped off. */
   private static URI toFileSystemUri(URI uri) {
     try {
       return new URI(
@@ -167,9 +164,7 @@ public final class SystemJimfsFileSystemProvider extends FileSystemProvider {
     }
   }
 
-  /**
-   * Invokes the {@code toPath(URI)} method on the given {@code FileSystem}.
-   */
+  /** Invokes the {@code toPath(URI)} method on the given {@code FileSystem}. */
   private static Path toPath(FileSystem fileSystem, URI uri) {
     // We have to invoke this method by reflection because while the file system should be
     // an instance of JimfsFileSystem, it may be loaded by a different class loader and as

--- a/jimfs/src/main/java/com/google/common/jimfs/UnixAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/UnixAttributeProvider.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.GroupPrincipal;
@@ -82,9 +81,7 @@ final class UnixAttributeProvider extends AttributeProvider {
   // providers to create their default principals using the lookup service for the specific file
   // system.
 
-  /**
-   * Returns an ID that is guaranteed to be the same for any invocation with equal objects.
-   */
+  /** Returns an ID that is guaranteed to be the same for any invocation with equal objects. */
   private Integer getUniqueId(Object object) {
     Integer id = idCache.get(object);
     if (id == null) {

--- a/jimfs/src/main/java/com/google/common/jimfs/UnixPathType.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/UnixPathType.java
@@ -19,7 +19,6 @@ package com.google.common.jimfs;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.nio.file.InvalidPathException;
-
 import javax.annotation.Nullable;
 
 /**
@@ -29,9 +28,7 @@ import javax.annotation.Nullable;
  */
 final class UnixPathType extends PathType {
 
-  /**
-   * Unix path type.
-   */
+  /** Unix path type. */
   static final PathType INSTANCE = new UnixPathType();
 
   private UnixPathType() {

--- a/jimfs/src/main/java/com/google/common/jimfs/UserDefinedAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/UserDefinedAttributeProvider.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.attribute.FileAttributeView;
@@ -110,9 +109,7 @@ final class UserDefinedAttributeProvider extends AttributeProvider {
     return new View(lookup);
   }
 
-  /**
-   * Implementation of {@link UserDefinedFileAttributeView}.
-   */
+  /** Implementation of {@link UserDefinedFileAttributeView}. */
   private static class View extends AbstractAttributeView implements UserDefinedFileAttributeView {
 
     public View(FileLookup lookup) {

--- a/jimfs/src/main/java/com/google/common/jimfs/UserLookupService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/UserLookupService.java
@@ -50,23 +50,17 @@ final class UserLookupService extends UserPrincipalLookupService {
     return createGroupPrincipal(group);
   }
 
-  /**
-   * Creates a {@link UserPrincipal} for the given user name.
-   */
+  /** Creates a {@link UserPrincipal} for the given user name. */
   static UserPrincipal createUserPrincipal(String name) {
     return new JimfsUserPrincipal(name);
   }
 
-  /**
-   * Creates a {@link GroupPrincipal} for the given group name.
-   */
+  /** Creates a {@link GroupPrincipal} for the given group name. */
   static GroupPrincipal createGroupPrincipal(String name) {
     return new JimfsGroupPrincipal(name);
   }
 
-  /**
-   * Base class for {@link UserPrincipal} and {@link GroupPrincipal} implementations.
-   */
+  /** Base class for {@link UserPrincipal} and {@link GroupPrincipal} implementations. */
   private abstract static class NamedPrincipal implements UserPrincipal {
 
     protected final String name;
@@ -91,9 +85,7 @@ final class UserLookupService extends UserPrincipalLookupService {
     }
   }
 
-  /**
-   * {@link UserPrincipal} implementation.
-   */
+  /** {@link UserPrincipal} implementation. */
   static final class JimfsUserPrincipal extends NamedPrincipal {
 
     private JimfsUserPrincipal(String name) {
@@ -107,9 +99,7 @@ final class UserLookupService extends UserPrincipalLookupService {
     }
   }
 
-  /**
-   * {@link GroupPrincipal} implementation.
-   */
+  /** {@link GroupPrincipal} implementation. */
   static final class JimfsGroupPrincipal extends NamedPrincipal implements GroupPrincipal {
 
     private JimfsGroupPrincipal(String name) {

--- a/jimfs/src/main/java/com/google/common/jimfs/Util.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Util.java
@@ -31,9 +31,7 @@ final class Util {
 
   private Util() {}
 
-  /**
-   * Returns the next power of 2 >= n.
-   */
+  /** Returns the next power of 2 >= n. */
   public static int nextPowerOf2(int n) {
     if (n == 0) {
       return 1;
@@ -50,9 +48,7 @@ final class Util {
     checkArgument(n >= 0, "%s must not be negative: %s", description, n);
   }
 
-  /**
-   * Checks that no element in the given iterable is null, throwing NPE if any is.
-   */
+  /** Checks that no element in the given iterable is null, throwing NPE if any is. */
   static void checkNoneNull(Iterable<?> objects) {
     if (!(objects instanceof ImmutableCollection)) {
       for (Object o : objects) {
@@ -80,9 +76,7 @@ final class Util {
   private static final byte[] ZERO_ARRAY = new byte[ARRAY_LEN];
   private static final byte[][] NULL_ARRAY = new byte[ARRAY_LEN][];
 
-  /**
-   * Zeroes all bytes between off (inclusive) and off + len (exclusive) in the given array.
-   */
+  /** Zeroes all bytes between off (inclusive) and off + len (exclusive) in the given array. */
   static void zero(byte[] bytes, int off, int len) {
     // this is significantly faster than looping or Arrays.fill (which loops), particularly when
     // the length of the slice to be zeroed is <= to ARRAY_LEN (in that case, it's faster by a
@@ -98,8 +92,8 @@ final class Util {
   }
 
   /**
-   * Clears (sets to null) all blocks between off (inclusive) and off + len (exclusive) in the
-   * given array.
+   * Clears (sets to null) all blocks between off (inclusive) and off + len (exclusive) in the given
+   * array.
    */
   static void clear(byte[][] blocks, int off, int len) {
     // this is significantly faster than looping or Arrays.fill (which loops), particularly when

--- a/jimfs/src/main/java/com/google/common/jimfs/WatchServiceConfiguration.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/WatchServiceConfiguration.java
@@ -31,9 +31,7 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class WatchServiceConfiguration {
 
-  /**
-   * The default configuration that's used if the user doesn't provide anything more specific.
-   */
+  /** The default configuration that's used if the user doesn't provide anything more specific. */
   static final WatchServiceConfiguration DEFAULT = polling(5, SECONDS);
 
   /**
@@ -48,16 +46,12 @@ public abstract class WatchServiceConfiguration {
 
   WatchServiceConfiguration() {}
 
-  /**
-   * Creates a new {@link AbstractWatchService} implementation.
-   */
+  /** Creates a new {@link AbstractWatchService} implementation. */
   // return type and parameters of this method subject to change if needed for any future
   // implementations
   abstract AbstractWatchService newWatchService(FileSystemView view, PathService pathService);
 
-  /**
-   * Implementation for {@link #polling}.
-   */
+  /** Implementation for {@link #polling}. */
   private static final class PollingConfig extends WatchServiceConfiguration {
 
     private final long interval;

--- a/jimfs/src/main/java/com/google/common/jimfs/WindowsPathType.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/WindowsPathType.java
@@ -20,7 +20,6 @@ import java.nio.file.InvalidPathException;
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
 
 /**
@@ -30,15 +29,13 @@ import javax.annotation.Nullable;
  */
 final class WindowsPathType extends PathType {
 
-  /**
-   * Windows path type.
-   */
+  /** Windows path type. */
   static final WindowsPathType INSTANCE = new WindowsPathType();
 
   /**
-   * Matches the C:foo\bar path format, which has a root (C:) and names (foo\bar) and matches
-   * a path relative to the working directory on that drive. Currently can't support that format
-   * as it requires behavior that differs completely from Unix.
+   * Matches the C:foo\bar path format, which has a root (C:) and names (foo\bar) and matches a path
+   * relative to the working directory on that drive. Currently can't support that format as it
+   * requires behavior that differs completely from Unix.
    */
   // TODO(cgdecker): Can probably support this at some point
   // It would require:
@@ -51,9 +48,7 @@ final class WindowsPathType extends PathType {
   //   working directory. For every other root, the root itself is the working directory.
   private static final Pattern WORKING_DIR_WITH_DRIVE = Pattern.compile("^[a-zA-Z]:([^\\\\].*)?$");
 
-  /**
-   * Pattern for matching trailing spaces in file names.
-   */
+  /** Pattern for matching trailing spaces in file names. */
   private static final Pattern TRAILING_SPACES = Pattern.compile("[ ]+(\\\\|$)");
 
   private WindowsPathType() {
@@ -109,14 +104,12 @@ final class WindowsPathType extends PathType {
     return new ParseResult(root, splitter().split(path));
   }
 
-  /**
-   * Pattern for matching UNC \\host\share root syntax.
-   */
+  /** Pattern for matching UNC \\host\share root syntax. */
   private static final Pattern UNC_ROOT = Pattern.compile("^(\\\\\\\\)([^\\\\]+)?(\\\\[^\\\\]+)?");
 
   /**
-   * Parse the root of a UNC-style path, throwing an exception if the path does not start with
-   * a valid UNC root.
+   * Parse the root of a UNC-style path, throwing an exception if the path does not start with a
+   * valid UNC root.
    */
   private String parseUncRoot(String path, String original) {
     Matcher uncMatcher = UNC_ROOT.matcher(path);
@@ -137,14 +130,10 @@ final class WindowsPathType extends PathType {
     }
   }
 
-  /**
-   * Pattern for matching normal C:\ drive letter root syntax.
-   */
+  /** Pattern for matching normal C:\ drive letter root syntax. */
   private static final Pattern DRIVE_LETTER_ROOT = Pattern.compile("^[a-zA-Z]:\\\\");
 
-  /**
-   * Parses a normal drive-letter root, e.g. "C:\".
-   */
+  /** Parses a normal drive-letter root, e.g. "C:\". */
   @Nullable
   private String parseDriveRoot(String path) {
     Matcher drivePathMatcher = DRIVE_LETTER_ROOT.matcher(path);
@@ -154,9 +143,7 @@ final class WindowsPathType extends PathType {
     return null;
   }
 
-  /**
-   * Checks if c is one of the reserved characters that aren't allowed in Windows file names.
-   */
+  /** Checks if c is one of the reserved characters that aren't allowed in Windows file names. */
   private static boolean isReserved(char c) {
     switch (c) {
       case '<':

--- a/jimfs/src/main/java/com/google/common/jimfs/package-info.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/package-info.java
@@ -16,8 +16,8 @@
 
 /**
  * Package containing the Jimfs file system API and implementation. Most users should only need to
- * use the {@link com.google.common.jimfs.Jimfs Jimfs} and
- * {@link com.google.common.jimfs.Configuration Configuration} classes.
+ * use the {@link com.google.common.jimfs.Jimfs Jimfs} and {@link
+ * com.google.common.jimfs.Configuration Configuration} classes.
  */
 @ParametersAreNonnullByDefault
 package com.google.common.jimfs;

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractAttributeProviderTest.java
@@ -20,13 +20,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
-
-import org.junit.Before;
-
 import java.io.IOException;
 import java.nio.file.attribute.FileAttributeView;
 import java.util.Map;
 import java.util.Set;
+import org.junit.Before;
 
 /**
  * Abstract base class for tests of individual {@link AttributeProvider} implementations.
@@ -41,14 +39,10 @@ public abstract class AbstractAttributeProviderTest<P extends AttributeProvider>
   protected P provider;
   protected File file;
 
-  /**
-   * Create the provider being tested.
-   */
+  /** Create the provider being tested. */
   protected abstract P createProvider();
 
-  /**
-   * Creates the set of providers the provider being tested depends on.
-   */
+  /** Creates the set of providers the provider being tested depends on. */
   protected abstract Set<? extends AttributeProvider> createInheritedProviders();
 
   protected FileLookup fileLookup() {

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractGlobMatcherTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractGlobMatcherTest.java
@@ -18,9 +18,7 @@ package com.google.common.jimfs;
 
 import org.junit.Test;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public abstract class AbstractGlobMatcherTest extends AbstractPathMatcherTest {
 
   @Test
@@ -32,14 +30,10 @@ public abstract class AbstractGlobMatcherTest extends AbstractPathMatcherTest {
 
   @Test
   public void testMatching_questionMark() {
-    assertThat("?")
-        .matches("a", "A", "$", "5", "_")
-        .doesNotMatch("/", "ab", "");
+    assertThat("?").matches("a", "A", "$", "5", "_").doesNotMatch("/", "ab", "");
     assertThat("??").matches("ab");
     assertThat("????").matches("1234");
-    assertThat("?oo?")
-        .matches("book", "doom")
-        .doesNotMatch("/oom");
+    assertThat("?oo?").matches("book", "doom").doesNotMatch("/oom");
     assertThat("/?oo/ba?").matches("/foo/bar");
     assertThat("foo.?").matches("foo.h");
     assertThat("foo.??").matches("foo.cc");
@@ -50,15 +44,11 @@ public abstract class AbstractGlobMatcherTest extends AbstractPathMatcherTest {
     assertThat("*")
         .matches("a", "abc", "298347829473928423", "abc12345", "")
         .doesNotMatch("/", "/abc");
-    assertThat("/*")
-        .matches("/a", "/abcd", "/abc123", "/")
-        .doesNotMatch("/foo/bar");
+    assertThat("/*").matches("/a", "/abcd", "/abc123", "/").doesNotMatch("/foo/bar");
     assertThat("/*/*/*")
         .matches("/a/b/c", "/foo/bar/baz")
         .doesNotMatch("/foo/bar", "/foo/bar/baz/abc");
-    assertThat("/*/bar")
-        .matches("/foo/bar", "/abc/bar")
-        .doesNotMatch("/bar");
+    assertThat("/*/bar").matches("/foo/bar", "/abc/bar").doesNotMatch("/bar");
     assertThat("/foo/*")
         .matches("/foo/bar", "/foo/baz")
         .doesNotMatch("/foo", "foo/bar", "/foo/bar/baz");
@@ -71,12 +61,9 @@ public abstract class AbstractGlobMatcherTest extends AbstractPathMatcherTest {
     assertThat("Foo.*")
         .matches("Foo.java", "Foo.txt", "Foo.tar.gz", "Foo.Foo.", "Foo.")
         .doesNotMatch("Foo", ".Foo");
-    assertThat("*/*.java")
-        .matches("foo/Bar.java", "foo/.java");
-    assertThat("*/Bar.*")
-        .matches("foo/Bar.java");
-    assertThat(".*")
-        .matches(".bashrc", ".bash_profile");
+    assertThat("*/*.java").matches("foo/Bar.java", "foo/.java");
+    assertThat("*/Bar.*").matches("foo/Bar.java");
+    assertThat(".*").matches(".bashrc", ".bash_profile");
     assertThat("*.............").matches(
         "............a............a..............a.............a............a.........." +
         ".........................................................a....................");
@@ -102,56 +89,36 @@ public abstract class AbstractGlobMatcherTest extends AbstractPathMatcherTest {
     assertThat("/foo/**/bar.txt")
         .matches("/foo/baz/bar.txt", "/foo/bar/asdf/bar.txt")
         .doesNotMatch("/foo/bar.txt", "/foo/baz/bar");
-    assertThat("**/*.java")
-        .matches("/Foo.java", "foo/Bar.java", "/.java", "foo/.java");
+    assertThat("**/*.java").matches("/Foo.java", "foo/Bar.java", "/.java", "foo/.java");
   }
 
   @Test
   public void testMatching_brackets() {
-    assertThat("[ab]")
-        .matches("a", "b")
-        .doesNotMatch("ab", "ba", "aa", "bb", "c", "", "/");
+    assertThat("[ab]").matches("a", "b").doesNotMatch("ab", "ba", "aa", "bb", "c", "", "/");
     assertThat("[a-d]")
         .matches("a", "b", "c", "d")
         .doesNotMatch("e", "f", "z", "aa", "ab", "abcd", "", "/");
     assertThat("[a-dz]")
         .matches("a", "b", "c", "d", "z")
         .doesNotMatch("e", "f", "aa", "ab", "dz", "", "/");
-    assertThat("[!b]")
-        .matches("a", "c", "d", "0", "!", "$")
-        .doesNotMatch("b", "/", "", "ac");
+    assertThat("[!b]").matches("a", "c", "d", "0", "!", "$").doesNotMatch("b", "/", "", "ac");
     assertThat("[!b-d3]")
         .matches("a", "e", "f", "0", "1", "2", "4")
         .doesNotMatch("b", "c", "d", "3");
     assertThat("[-]").matches("-");
     assertThat("[-a-c]").matches("-", "a", "b", "c");
-    assertThat("[!-a-c]")
-        .matches("d", "e", "0")
-        .doesNotMatch("a", "b", "c", "-");
-    assertThat("[\\d]")
-        .matches("\\", "d")
-        .doesNotMatch("0", "1");
-    assertThat("[\\s]")
-        .matches("\\", "s")
-        .doesNotMatch(" ");
-    assertThat("[\\]")
-        .matches("\\")
-        .doesNotMatch("]");
+    assertThat("[!-a-c]").matches("d", "e", "0").doesNotMatch("a", "b", "c", "-");
+    assertThat("[\\d]").matches("\\", "d").doesNotMatch("0", "1");
+    assertThat("[\\s]").matches("\\", "s").doesNotMatch(" ");
+    assertThat("[\\]").matches("\\").doesNotMatch("]");
   }
 
   @Test
   public void testMatching_curlyBraces() {
-    assertThat("{a,b}")
-        .matches("a", "b")
-        .doesNotMatch("/", "c", "0", "", ",", "{", "}");
-    assertThat("{ab,cd}")
-        .matches("ab", "cd")
-        .doesNotMatch("bc", "ac", "ad", "ba", "dc", ",");
-    assertThat(".{h,cc}")
-        .matches(".h", ".cc")
-        .doesNotMatch("h", "cc");
-    assertThat("{?oo,ba?}")
-        .matches("foo", "boo", "moo", "bat", "bar", "baz");
+    assertThat("{a,b}").matches("a", "b").doesNotMatch("/", "c", "0", "", ",", "{", "}");
+    assertThat("{ab,cd}").matches("ab", "cd").doesNotMatch("bc", "ac", "ad", "ba", "dc", ",");
+    assertThat(".{h,cc}").matches(".h", ".cc").doesNotMatch("h", "cc");
+    assertThat("{?oo,ba?}").matches("foo", "boo", "moo", "bat", "bar", "baz");
     assertThat("{[Ff]oo*,[Bb]a*,[A-Ca-c]*/[!z]*.txt}")
         .matches("foo", "Foo", "fools", "ba", "Ba", "bar", "Bar", "Bart", "c/y.txt", "Cat/foo.txt")
         .doesNotMatch("Cat", "Cat/foo", "blah", "bAr", "c/z.txt", "c/.txt", "*");
@@ -166,9 +133,7 @@ public abstract class AbstractGlobMatcherTest extends AbstractPathMatcherTest {
     assertThat("\\{").matches("{");
     assertThat("\\a").matches("a");
     assertThat("{a,\\}}").matches("a", "}");
-    assertThat("{a\\,,b}")
-        .matches("a,", "b")
-        .doesNotMatch("a", ",");
+    assertThat("{a\\,,b}").matches("a,", "b").doesNotMatch("a", ",");
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractJimfsIntegrationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractJimfsIntegrationTest.java
@@ -20,9 +20,6 @@ import static com.google.common.jimfs.PathSubject.paths;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
 
-import org.junit.After;
-import org.junit.Before;
-
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -30,10 +27,10 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
+import org.junit.After;
+import org.junit.Before;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public abstract class AbstractJimfsIntegrationTest {
 
   protected FileSystem fs;
@@ -48,9 +45,7 @@ public abstract class AbstractJimfsIntegrationTest {
     fs.close();
   }
 
-  /**
-   * Creates the file system to use in the tests.
-   */
+  /** Creates the file system to use in the tests. */
   protected abstract FileSystem createFileSystem();
 
   // helpers
@@ -75,9 +70,7 @@ public abstract class AbstractJimfsIntegrationTest {
     return subject;
   }
 
-  /**
-   * Tester for testing changes in file times.
-   */
+  /** Tester for testing changes in file times. */
   protected static final class FileTimeTester {
 
     private final Path path;

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractPathMatcherTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractPathMatcherTest.java
@@ -33,7 +33,6 @@ import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.Iterator;
 import java.util.regex.PatternSyntaxException;
-
 import javax.annotation.Nullable;
 
 /**
@@ -48,9 +47,7 @@ public abstract class AbstractPathMatcherTest {
    */
   protected abstract PathMatcher matcher(String pattern);
 
-  /**
-   * Override to return a real matcher for the given pattern.
-   */
+  /** Override to return a real matcher for the given pattern. */
   @Nullable
   protected PathMatcher realMatcher(String pattern) {
     return null;
@@ -117,9 +114,7 @@ public abstract class AbstractPathMatcherTest {
     }
   }
 
-  /**
-   * Path that only provides toString().
-   */
+  /** Path that only provides toString(). */
   private static Path fake(final String path) {
     return new Path() {
       @Override

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractWatchServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractWatchServiceTest.java
@@ -28,12 +28,6 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.Path;
@@ -43,6 +37,10 @@ import java.nio.file.WatchService;
 import java.nio.file.Watchable;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link AbstractWatchService}.
@@ -236,9 +234,7 @@ public class AbstractWatchServiceTest {
 
   // TODO(cgdecker): Test concurrent use of Watcher
 
-  /**
-   * A fake {@link Watchable} for testing.
-   */
+  /** A fake {@link Watchable} for testing. */
   private static final class StubWatchable implements Watchable {
 
     @Override

--- a/jimfs/src/test/java/com/google/common/jimfs/AclAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AclAttributeProviderTest.java
@@ -27,11 +27,6 @@ import static org.junit.Assert.assertNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclFileAttributeView;
@@ -39,6 +34,9 @@ import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Map;
 import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link AclAttributeProvider}.

--- a/jimfs/src/test/java/com/google/common/jimfs/AttributeServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AttributeServiceTest.java
@@ -21,12 +21,6 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.attribute.BasicFileAttributeView;
@@ -34,6 +28,10 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link AttributeService}.
@@ -274,12 +272,7 @@ public class AttributeServiceTest {
     service.setInitialAttributes(file);
 
     ImmutableMap<String, Object> map = service.readAttributes(file, "test:foo,bar,baz");
-    assertThat(map)
-        .isEqualTo(
-            ImmutableMap.of(
-                "foo", "hello",
-                "bar", 0L,
-                "baz", 1));
+    assertThat(map).isEqualTo(ImmutableMap.of("foo", "hello", "bar", 0L, "baz", 1));
 
     FileTime time = (FileTime) service.getAttribute(file, "basic:creationTime");
 

--- a/jimfs/src/test/java/com/google/common/jimfs/BasicAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/BasicAttributeProviderTest.java
@@ -20,16 +20,14 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link BasicAttributeProvider}.

--- a/jimfs/src/test/java/com/google/common/jimfs/BasicFileAttribute.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/BasicFileAttribute.java
@@ -20,9 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.nio.file.attribute.FileAttribute;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public class BasicFileAttribute<T> implements FileAttribute<T> {
 
   private final String name;

--- a/jimfs/src/test/java/com/google/common/jimfs/ByteBufferChannel.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ByteBufferChannel.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public class ByteBufferChannel implements SeekableByteChannel {
 
   private final ByteBuffer buffer;

--- a/jimfs/src/test/java/com/google/common/jimfs/ClassLoaderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ClassLoaderTest.java
@@ -23,11 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
@@ -36,11 +31,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
- * Tests behavior when user code loads Jimfs in a separate class loader from the system class
- * loader (which is what {@link FileSystemProvider#installedProviders()} uses to load
- * {@link FileSystemProvider}s as services from the classpath).
+ * Tests behavior when user code loads Jimfs in a separate class loader from the system class loader
+ * (which is what {@link FileSystemProvider#installedProviders()} uses to load {@link
+ * FileSystemProvider}s as services from the classpath).
  *
  * @author Colin Decker
  */
@@ -97,12 +95,12 @@ public class ClassLoaderTest {
   }
 
   /**
-   * This method is really just testing that {@code Jimfs.newFileSystem()} succeeds. Without
-   * special handling, when the system class loader loads our {@code FileSystemProvider}
-   * implementation as a service and this code (the user code) is loaded in a separate class
-   * loader, the system-loaded provider won't see the instance of {@code Configuration} we give it
-   * as being an instance of the {@code Configuration} it's expecting (they're completely separate
-   * classes) and creation of the file system will fail.
+   * This method is really just testing that {@code Jimfs.newFileSystem()} succeeds. Without special
+   * handling, when the system class loader loads our {@code FileSystemProvider} implementation as a
+   * service and this code (the user code) is loaded in a separate class loader, the system-loaded
+   * provider won't see the instance of {@code Configuration} we give it as being an instance of the
+   * {@code Configuration} it's expecting (they're completely separate classes) and creation of the
+   * file system will fail.
    */
   public static FileSystem createFileSystem() throws IOException {
     FileSystem fs = Jimfs.newFileSystem(Configuration.unix());

--- a/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
@@ -30,11 +30,6 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
@@ -42,7 +37,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link Configuration}, {@link Configuration.Builder} and file systems created from
@@ -244,8 +241,7 @@ public class ConfigurationTest {
   @Test
   public void testToBuilder() {
     Configuration config =
-        Configuration.unix()
-            .toBuilder()
+        Configuration.unix().toBuilder()
             .setWorkingDirectory("/hello/world")
             .setAttributeViews("basic", "posix")
             .build();
@@ -331,8 +327,7 @@ public class ConfigurationTest {
   public void testCreateFileSystemFromConfigurationWithWorkingDirectoryNotUnderConfiguredRoot() {
     try {
       Jimfs.newFileSystem(
-          Configuration.windows()
-              .toBuilder()
+          Configuration.windows().toBuilder()
               .setRoots("C:\\", "D:\\")
               .setWorkingDirectory("E:\\foo")
               .build());
@@ -355,9 +350,11 @@ public class ConfigurationTest {
 
   @Test
   public void testFileSystemWithCustomWatchServicePollingInterval() throws IOException {
-    FileSystem fs = Jimfs.newFileSystem(Configuration.unix().toBuilder()
-        .setWatchServiceConfiguration(polling(10, MILLISECONDS))
-        .build());
+    FileSystem fs =
+        Jimfs.newFileSystem(
+            Configuration.unix().toBuilder()
+                .setWatchServiceConfiguration(polling(10, MILLISECONDS))
+                .build());
 
     WatchService watchService = fs.newWatchService();
     assertThat(watchService).isInstanceOf(PollingWatchService.class);

--- a/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
@@ -26,16 +26,13 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
-
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.annotation.Nullable;
 
 /**
  * Tests for {@link Directory}.

--- a/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
@@ -258,7 +258,7 @@ public class DirectoryTest {
     dir.put(entry("bar"));
 
     assertThat(dir.entryCount()).isEqualTo(4);
-    assertThat(ImmutableSet.copyOf(dir)).containsAllOf(entry("foo"), entry("bar"));
+    assertThat(ImmutableSet.copyOf(dir)).containsAtLeast(entry("foo"), entry("bar"));
     assertThat(dir.get(Name.simple("foo"))).isEqualTo(entry("foo"));
     assertThat(dir.get(Name.simple("bar"))).isEqualTo(entry("bar"));
   }

--- a/jimfs/src/test/java/com/google/common/jimfs/DosAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/DosAttributeProviderTest.java
@@ -22,17 +22,15 @@ import static org.junit.Assert.assertNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.nio.file.attribute.DosFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link DosAttributeProvider}.

--- a/jimfs/src/test/java/com/google/common/jimfs/FileSystemStateTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/FileSystemStateTest.java
@@ -23,15 +23,13 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.ClosedFileSystemException;
 import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link FileSystemState}.

--- a/jimfs/src/test/java/com/google/common/jimfs/FileTreeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/FileTreeTest.java
@@ -25,20 +25,17 @@ import static org.junit.Assert.fail;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-
 import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link FileTree}.
@@ -71,10 +68,10 @@ public class FileTreeTest {
 
   /**
    * This path service is for unix-like paths, with the exception that it recognizes $ and ! as
-   * roots in addition to /, allowing for up to three roots. When creating a
-   * {@linkplain PathType#toUriPath URI path}, we prefix the path with / to differentiate between
-   * a path like "$foo/bar" and one like "/$foo/bar". They would become "/$foo/bar" and
-   * "//$foo/bar" respectively.
+   * roots in addition to /, allowing for up to three roots. When creating a {@linkplain
+   * PathType#toUriPath URI path}, we prefix the path with / to differentiate between a path like
+   * "$foo/bar" and one like "/$foo/bar". They would become "/$foo/bar" and "//$foo/bar"
+   * respectively.
    */
   private final PathService pathService =
       PathServiceTest.fakePathService(

--- a/jimfs/src/test/java/com/google/common/jimfs/HeapDiskTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/HeapDiskTest.java
@@ -19,14 +19,13 @@ package com.google.common.jimfs;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Tests for {@link HeapDisk}.
@@ -57,8 +56,7 @@ public class HeapDiskTest {
   @Test
   public void testInitialSettings_fromConfiguration() {
     Configuration config =
-        Configuration.unix()
-            .toBuilder()
+        Configuration.unix().toBuilder()
             .setBlockSize(4)
             .setMaxSize(99) // not a multiple of 4
             .setMaxCacheSize(25)

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsAsynchronousFileChannelTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsAsynchronousFileChannelTest.java
@@ -33,11 +33,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
@@ -50,6 +45,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link JimfsAsynchronousFileChannel}.
@@ -222,21 +220,19 @@ public class JimfsAsynchronousFileChannelTest {
    */
   private static <T> CompletionHandler<T, Object> setFuture(final SettableFuture<T> future) {
     return new CompletionHandler<T, Object>() {
-        @Override
-        public void completed(T result, Object attachment) {
-          future.set(result);
-        }
+      @Override
+      public void completed(T result, Object attachment) {
+        future.set(result);
+      }
 
-        @Override
-        public void failed(Throwable exc, Object attachment) {
-          future.setException(exc);
-        }
-      };
+      @Override
+      public void failed(Throwable exc, Object attachment) {
+        future.setException(exc);
+      }
+    };
   }
 
-  /**
-   * Assert that the future fails, with the failure caused by {@code ClosedChannelException}.
-   */
+  /** Assert that the future fails, with the failure caused by {@code ClosedChannelException}. */
   private static void assertClosed(Future<?> future) throws Throwable {
     try {
       future.get(10, SECONDS);
@@ -247,8 +243,8 @@ public class JimfsAsynchronousFileChannelTest {
   }
 
   /**
-   * Assert that the future fails, with the failure caused by either
-   * {@code AsynchronousCloseException} or (rarely) {@code ClosedChannelException}.
+   * Assert that the future fails, with the failure caused by either {@code
+   * AsynchronousCloseException} or (rarely) {@code ClosedChannelException}.
    */
   private static void assertAsynchronousClose(Future<?> future) throws Throwable {
     try {
@@ -257,8 +253,9 @@ public class JimfsAsynchronousFileChannelTest {
     } catch (ExecutionException expected) {
       Throwable t = expected.getCause();
       if (!(t instanceof AsynchronousCloseException || t instanceof ClosedChannelException)) {
-        fail("expected AsynchronousCloseException (or in rare cases ClosedChannelException): "
-            + "got " + t);
+        fail(
+            "expected AsynchronousCloseException (or in rare cases ClosedChannelException); got "
+                + t);
       }
     }
   }

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsFileChannelTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsFileChannelTest.java
@@ -20,7 +20,7 @@ import static com.google.common.jimfs.TestUtils.assertNotEquals;
 import static com.google.common.jimfs.TestUtils.buffer;
 import static com.google.common.jimfs.TestUtils.bytes;
 import static com.google.common.jimfs.TestUtils.regularFile;
-import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -695,8 +695,8 @@ public class JimfsFileChannelTest {
         future.get();
         fail();
       } catch (ExecutionException expected) {
-        assertThat(expected.getCause())
-            .named("blocking thread exception")
+        assertWithMessage("blocking thread exception")
+            .that(expected.getCause())
             .isInstanceOf(AsynchronousCloseException.class);
       }
     }
@@ -754,8 +754,8 @@ public class JimfsFileChannelTest {
     thread.interrupt();
 
     // get the exception that caused the interrupted operation to terminate
-    assertThat(interruptException.get(200, MILLISECONDS))
-        .named("interrupted thread exception")
+    assertWithMessage("interrupted thread exception")
+        .that(interruptException.get(200, MILLISECONDS))
         .isInstanceOf(ClosedByInterruptException.class);
 
     // check that each other thread got AsynchronousCloseException (since the interrupt, on a
@@ -765,8 +765,8 @@ public class JimfsFileChannelTest {
         future.get();
         fail();
       } catch (ExecutionException expected) {
-        assertThat(expected.getCause())
-            .named("blocking thread exception")
+        assertWithMessage("blocking thread exception")
+            .that(expected.getCause())
             .isInstanceOf(AsynchronousCloseException.class);
       }
     }

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsFileChannelTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsFileChannelTest.java
@@ -37,11 +37,6 @@ import com.google.common.testing.NullPointerTester;
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
@@ -61,11 +56,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Most of the behavior of {@link JimfsFileChannel} is handled by the {@link RegularFile}
- * implementations, so the thorough tests of that are in {@link RegularFileTest}. This mostly
- * tests interactions with the file and channel positions.
+ * implementations, so the thorough tests of that are in {@link RegularFileTest}. This mostly tests
+ * interactions with the file and channel positions.
  *
  * @author Colin Decker
  */
@@ -777,9 +775,9 @@ public class JimfsFileChannelTest {
   private static final int BLOCKING_OP_COUNT = 10;
 
   /**
-   * Queues blocking operations on the channel in separate threads using the given executor.
-   * The given latch should have a count of BLOCKING_OP_COUNT to allow the caller wants to wait for
-   * all threads to start executing.
+   * Queues blocking operations on the channel in separate threads using the given executor. The
+   * given latch should have a count of BLOCKING_OP_COUNT to allow the caller wants to wait for all
+   * threads to start executing.
    */
   private List<Future<?>> queueAllBlockingOperations(
       final FileChannel channel, ExecutorService executor, final CountDownLatch startLatch) {
@@ -901,8 +899,7 @@ public class JimfsFileChannelTest {
 
   /**
    * Tests that the methods on the default FileChannel that support InterruptibleChannel behavior
-   * also support it on JimfsFileChannel, by just interrupting the thread before calling the
-   * method.
+   * also support it on JimfsFileChannel, by just interrupting the thread before calling the method.
    */
   @Test
   public void testInterruptedThreads() throws IOException {
@@ -1030,9 +1027,9 @@ public class JimfsFileChannelTest {
   }
 
   /**
-   * Asserts that when the given operation is run on an interrupted thread,
-   * {@code ClosedByInterruptException} is thrown, the channel is closed and the thread is no
-   * longer interrupted.
+   * Asserts that when the given operation is run on an interrupted thread, {@code
+   * ClosedByInterruptException} is thrown, the channel is closed and the thread is no longer
+   * interrupted.
    */
   private static void assertClosedByInterrupt(FileChannelMethod method) throws IOException {
     FileChannel channel = channel(regularFile(10), READ, WRITE);

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsInputStreamTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsInputStreamTest.java
@@ -23,12 +23,10 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
 
 import com.google.common.util.concurrent.Runnables;
-
+import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.io.IOException;
 
 /**
  * Tests for {@link JimfsInputStream}.

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsOutputStreamTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsOutputStreamTest.java
@@ -23,14 +23,12 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
 
 import com.google.common.util.concurrent.Runnables;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link JimfsOutputStream}.
@@ -171,8 +169,8 @@ public class JimfsOutputStreamTest {
     out.flush(); // does nothing
 
     try (JimfsOutputStream out2 = newOutputStream(false);
-         BufferedOutputStream bout = new BufferedOutputStream(out2);
-         OutputStreamWriter writer = new OutputStreamWriter(bout, UTF_8)) {
+        BufferedOutputStream bout = new BufferedOutputStream(out2);
+        OutputStreamWriter writer = new OutputStreamWriter(bout, UTF_8)) {
       /*
        * This specific scenario is why flush() shouldn't throw when the stream is already closed.
        * Nesting try-with-resources like this will cause close() to be called on the

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsPathTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsPathTest.java
@@ -21,15 +21,13 @@ import static org.junit.Assert.fail;
 
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link JimfsPath}.
@@ -61,7 +59,7 @@ public class JimfsPathTest {
     assertPathEquals("/foo/bar", "///foo/bar");
     assertPathEquals("/foo/bar", "/foo///bar//");
     assertPathEquals("/foo/bar/baz", "/foo", "/bar", "baz/");
-    //assertPathEquals("/foo/bar/baz", "/foo\\/bar//\\\\/baz\\/");
+    // assertPathEquals("/foo/bar/baz", "/foo\\/bar//\\\\/baz\\/");
   }
 
   @Test
@@ -140,23 +138,18 @@ public class JimfsPathTest {
   @Test
   public void testRelativePath_fourNames() {
     new PathTester(pathService, "foo/bar/baz/test")
-        .names("foo", "bar", "baz", "test").test("foo/bar/baz/test");
+        .names("foo", "bar", "baz", "test")
+        .test("foo/bar/baz/test");
   }
 
   @Test
   public void testAbsolutePath_singleName() {
-    new PathTester(pathService, "/foo")
-        .root("/")
-        .names("foo")
-        .test("/foo");
+    new PathTester(pathService, "/foo").root("/").names("foo").test("/foo");
   }
 
   @Test
   public void testAbsolutePath_twoNames() {
-    new PathTester(pathService, "/foo/bar")
-        .root("/")
-        .names("foo", "bar")
-        .test("/foo/bar");
+    new PathTester(pathService, "/foo/bar").root("/").names("foo", "bar").test("/foo/bar");
   }
 
   @Test
@@ -333,10 +326,7 @@ public class JimfsPathTest {
     Path path2 = pathService.createFileName(a2);
     Path path3 = pathService.createFileName(a3);
 
-    new EqualsTester()
-        .addEqualityGroup(path1, path3)
-        .addEqualityGroup(path2)
-        .testEquals();
+    new EqualsTester().addEqualityGroup(path1, path3).addEqualityGroup(path2).testEquals();
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
@@ -109,8 +109,7 @@ import org.junit.runners.JUnit4;
 public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
   private static final Configuration UNIX_CONFIGURATION =
-      Configuration.unix()
-          .toBuilder()
+      Configuration.unix().toBuilder()
           .setAttributeViews("basic", "owner", "posix", "unix")
           .setMaxSize(1024 * 1024 * 1024) // 1 GB
           .setMaxCacheSize(256 * 1024 * 1024) // 256 MB
@@ -166,16 +165,15 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
   @Test
   public void testPaths() {
-    assertThatPath("/").isAbsolute()
-        .and().hasRootComponent("/")
-        .and().hasNoNameComponents();
-    assertThatPath("foo").isRelative()
-        .and().hasNameComponents("foo");
-    assertThatPath("foo/bar").isRelative()
-        .and().hasNameComponents("foo", "bar");
-    assertThatPath("/foo/bar/baz").isAbsolute()
-        .and().hasRootComponent("/")
-        .and().hasNameComponents("foo", "bar", "baz");
+    assertThatPath("/").isAbsolute().and().hasRootComponent("/").and().hasNoNameComponents();
+    assertThatPath("foo").isRelative().and().hasNameComponents("foo");
+    assertThatPath("foo/bar").isRelative().and().hasNameComponents("foo", "bar");
+    assertThatPath("/foo/bar/baz")
+        .isAbsolute()
+        .and()
+        .hasRootComponent("/")
+        .and()
+        .hasNameComponents("foo", "bar", "baz");
   }
 
   @Test
@@ -198,42 +196,64 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
   @Test
   public void testPaths_resolve() {
-    assertThatPath(path("/").resolve("foo/bar")).isAbsolute()
-        .and().hasRootComponent("/")
-        .and().hasNameComponents("foo", "bar");
-    assertThatPath(path("foo/bar").resolveSibling("baz")).isRelative()
-        .and().hasNameComponents("foo", "baz");
-    assertThatPath(path("foo/bar").resolve("/one/two")).isAbsolute()
-        .and().hasRootComponent("/")
-        .and().hasNameComponents("one", "two");
+    assertThatPath(path("/").resolve("foo/bar"))
+        .isAbsolute()
+        .and()
+        .hasRootComponent("/")
+        .and()
+        .hasNameComponents("foo", "bar");
+    assertThatPath(path("foo/bar").resolveSibling("baz"))
+        .isRelative()
+        .and()
+        .hasNameComponents("foo", "baz");
+    assertThatPath(path("foo/bar").resolve("/one/two"))
+        .isAbsolute()
+        .and()
+        .hasRootComponent("/")
+        .and()
+        .hasNameComponents("one", "two");
   }
 
   @Test
   public void testPaths_normalize() {
-    assertThatPath(path("foo/bar/..").normalize()).isRelative()
-        .and().hasNameComponents("foo");
-    assertThatPath(path("foo/./bar/../baz/test/./../stuff").normalize()).isRelative()
-        .and().hasNameComponents("foo", "baz", "stuff");
-    assertThatPath(path("../../foo/./bar").normalize()).isRelative()
-        .and().hasNameComponents("..", "..", "foo", "bar");
-    assertThatPath(path("foo/../../bar").normalize()).isRelative()
-        .and().hasNameComponents("..", "bar");
-    assertThatPath(path(".././..").normalize()).isRelative()
-        .and().hasNameComponents("..", "..");
+    assertThatPath(path("foo/bar/..").normalize()).isRelative().and().hasNameComponents("foo");
+    assertThatPath(path("foo/./bar/../baz/test/./../stuff").normalize())
+        .isRelative()
+        .and()
+        .hasNameComponents("foo", "baz", "stuff");
+    assertThatPath(path("../../foo/./bar").normalize())
+        .isRelative()
+        .and()
+        .hasNameComponents("..", "..", "foo", "bar");
+    assertThatPath(path("foo/../../bar").normalize())
+        .isRelative()
+        .and()
+        .hasNameComponents("..", "bar");
+    assertThatPath(path(".././..").normalize()).isRelative().and().hasNameComponents("..", "..");
   }
 
   @Test
   public void testPaths_relativize() {
-    assertThatPath(path("/foo/bar").relativize(path("/foo/bar/baz"))).isRelative()
-        .and().hasNameComponents("baz");
-    assertThatPath(path("/foo/bar/baz").relativize(path("/foo/bar"))).isRelative()
-        .and().hasNameComponents("..");
-    assertThatPath(path("/foo/bar/baz").relativize(path("/foo/baz/bar"))).isRelative()
-        .and().hasNameComponents("..", "..", "baz", "bar");
-    assertThatPath(path("foo/bar").relativize(path("foo"))).isRelative()
-        .and().hasNameComponents("..");
-    assertThatPath(path("foo").relativize(path("foo/bar"))).isRelative()
-        .and().hasNameComponents("bar");
+    assertThatPath(path("/foo/bar").relativize(path("/foo/bar/baz")))
+        .isRelative()
+        .and()
+        .hasNameComponents("baz");
+    assertThatPath(path("/foo/bar/baz").relativize(path("/foo/bar")))
+        .isRelative()
+        .and()
+        .hasNameComponents("..");
+    assertThatPath(path("/foo/bar/baz").relativize(path("/foo/baz/bar")))
+        .isRelative()
+        .and()
+        .hasNameComponents("..", "..", "baz", "bar");
+    assertThatPath(path("foo/bar").relativize(path("foo")))
+        .isRelative()
+        .and()
+        .hasNameComponents("..");
+    assertThatPath(path("foo").relativize(path("foo/bar")))
+        .isRelative()
+        .and()
+        .hasNameComponents("bar");
 
     try {
       Path unused = path("/foo/bar").relativize(path("bar"));
@@ -262,15 +282,23 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
   @Test
   public void testPaths_toAbsolutePath() {
-    assertThatPath(path("/foo/bar").toAbsolutePath()).isAbsolute()
-        .and().hasRootComponent("/")
-        .and().hasNameComponents("foo", "bar")
-        .and().isEqualTo(path("/foo/bar"));
+    assertThatPath(path("/foo/bar").toAbsolutePath())
+        .isAbsolute()
+        .and()
+        .hasRootComponent("/")
+        .and()
+        .hasNameComponents("foo", "bar")
+        .and()
+        .isEqualTo(path("/foo/bar"));
 
-    assertThatPath(path("foo/bar").toAbsolutePath()).isAbsolute()
-        .and().hasRootComponent("/")
-        .and().hasNameComponents("work", "foo", "bar")
-        .and().isEqualTo(path("/work/foo/bar"));
+    assertThatPath(path("foo/bar").toAbsolutePath())
+        .isAbsolute()
+        .and()
+        .hasRootComponent("/")
+        .and()
+        .hasNameComponents("work", "foo", "bar")
+        .and()
+        .isEqualTo(path("/work/foo/bar"));
   }
 
   @Test
@@ -402,10 +430,7 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
     Files.createDirectory(path("/foo"));
     Files.createSymbolicLink(path("/foo/link.txt"), path("test.txt"));
 
-    assertThatPath("/foo/link.txt")
-        .noFollowLinks()
-        .isSymbolicLink()
-        .withTarget("test.txt");
+    assertThatPath("/foo/link.txt").noFollowLinks().isSymbolicLink().withTarget("test.txt");
     assertThatPath("/foo").hasChildren("link.txt");
   }
 
@@ -684,8 +709,11 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
         PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx"));
     Files.newByteChannel(path("/foo"), ImmutableSet.of(WRITE, CREATE), permissions).close();
 
-    assertThatPath("/foo").isRegularFile()
-        .and().attribute("posix:permissions").is(permissions.value());
+    assertThatPath("/foo")
+        .isRegularFile()
+        .and()
+        .attribute("posix:permissions")
+        .is(permissions.value());
   }
 
   @Test
@@ -696,8 +724,11 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
         PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx"));
     Files.newByteChannel(path("/foo"), ImmutableSet.of(WRITE, CREATE), permissions).close();
 
-    assertThatPath("/foo").isRegularFile()
-        .and().attribute("posix:permissions").isNot(permissions.value());
+    assertThatPath("/foo")
+        .isRegularFile()
+        .and()
+        .attribute("posix:permissions")
+        .isNot(permissions.value());
   }
 
   @Test
@@ -707,13 +738,19 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
     Files.createDirectory(path("/foo"), permissions);
 
-    assertThatPath("/foo").isDirectory()
-        .and().attribute("posix:permissions").is(permissions.value());
+    assertThatPath("/foo")
+        .isDirectory()
+        .and()
+        .attribute("posix:permissions")
+        .is(permissions.value());
 
     Files.createDirectory(path("/normal"));
 
-    assertThatPath("/normal").isDirectory()
-        .and().attribute("posix:permissions").isNot(permissions.value());
+    assertThatPath("/normal")
+        .isDirectory()
+        .and()
+        .attribute("posix:permissions")
+        .isNot(permissions.value());
   }
 
   @Test
@@ -723,13 +760,19 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
     Files.createSymbolicLink(path("/foo"), path("bar"), permissions);
 
-    assertThatPath("/foo", NOFOLLOW_LINKS).isSymbolicLink()
-        .and().attribute("posix:permissions").is(permissions.value());
+    assertThatPath("/foo", NOFOLLOW_LINKS)
+        .isSymbolicLink()
+        .and()
+        .attribute("posix:permissions")
+        .is(permissions.value());
 
     Files.createSymbolicLink(path("/normal"), path("bar"));
 
-    assertThatPath("/normal", NOFOLLOW_LINKS).isSymbolicLink()
-        .and().attribute("posix:permissions").isNot(permissions.value());
+    assertThatPath("/normal", NOFOLLOW_LINKS)
+        .isSymbolicLink()
+        .and()
+        .attribute("posix:permissions")
+        .isNot(permissions.value());
   }
 
   @Test
@@ -1294,9 +1337,13 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
     Files.createLink(path("/link"), path("/symlink"));
 
-    assertThatPath("/link").isRegularFile()
-        .and().hasLinkCount(2)
-        .and().attribute("fileKey").is(key);
+    assertThatPath("/link")
+        .isRegularFile()
+        .and()
+        .hasLinkCount(2)
+        .and()
+        .attribute("fileKey")
+        .is(key);
   }
 
   @Test
@@ -1711,8 +1758,7 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
       Files.copy(foo, foo2);
 
       assertThatPath(foo).exists();
-      assertThatPath(foo2).exists()
-          .and().containsBytes(bytes);
+      assertThatPath(foo2).exists().and().containsBytes(bytes);
     }
   }
 
@@ -1737,14 +1783,25 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
       // when copying with COPY_ATTRIBUTES to a different FileSystem, only basic attributes (that
       // is, file times) can actually be copied
-      assertThatPath(foo2).exists()
-          .and().attribute("lastModifiedTime").is(FileTime.fromMillis(0))
-          .and().attribute("lastAccessTime").is(FileTime.fromMillis(1))
-          .and().attribute("creationTime").is(FileTime.fromMillis(2))
-          .and().attribute("owner:owner").isNot(owner)
-          .and().attribute("owner:owner")
-              .isNot(fs2.getUserPrincipalLookupService().lookupPrincipalByName("foobar"))
-          .and().containsBytes(bytes); // do this last; it updates the access time
+      assertThatPath(foo2)
+          .exists()
+          .and()
+          .attribute("lastModifiedTime")
+          .is(FileTime.fromMillis(0))
+          .and()
+          .attribute("lastAccessTime")
+          .is(FileTime.fromMillis(1))
+          .and()
+          .attribute("creationTime")
+          .is(FileTime.fromMillis(2))
+          .and()
+          .attribute("owner:owner")
+          .isNot(owner)
+          .and()
+          .attribute("owner:owner")
+          .isNot(fs2.getUserPrincipalLookupService().lookupPrincipalByName("foobar"))
+          .and()
+          .containsBytes(bytes); // do this last; it updates the access time
     }
   }
 
@@ -1756,20 +1813,26 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
     Object fooKey = getFileKey("/foo");
 
     Files.move(path("/foo"), path("/bar"));
-    assertThatPath("/foo").doesNotExist()
-        .andThat("/bar").containsBytes(bytes)
-        .and().attribute("fileKey").is(fooKey);
+    assertThatPath("/foo")
+        .doesNotExist()
+        .andThat("/bar")
+        .containsBytes(bytes)
+        .and()
+        .attribute("fileKey")
+        .is(fooKey);
 
     Files.createDirectory(path("/foo"));
     Files.move(path("/bar"), path("/foo/bar"));
 
-    assertThatPath("/bar").doesNotExist()
-        .andThat("/foo/bar").isRegularFile();
+    assertThatPath("/bar").doesNotExist().andThat("/foo/bar").isRegularFile();
 
     Files.move(path("/foo"), path("/baz"));
-    assertThatPath("/foo").doesNotExist()
-        .andThat("/baz").isDirectory()
-        .andThat("/baz/bar").isRegularFile();
+    assertThatPath("/foo")
+        .doesNotExist()
+        .andThat("/baz")
+        .isDirectory()
+        .andThat("/baz/bar")
+        .isRegularFile();
   }
 
   @Test
@@ -1781,15 +1844,13 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
     Files.move(path("/link"), path("/link.txt"));
 
-    assertThatPath("/foo.txt").noFollowLinks().isRegularFile()
-        .and().containsBytes(bytes);
+    assertThatPath("/foo.txt").noFollowLinks().isRegularFile().and().containsBytes(bytes);
 
     assertThatPath(path("/link")).doesNotExist();
 
     assertThatPath(path("/link.txt")).noFollowLinks().isSymbolicLink();
 
-    assertThatPath(path("/link.txt")).isRegularFile()
-        .and().containsBytes(bytes);
+    assertThatPath(path("/link.txt")).isRegularFile().and().containsBytes(bytes);
   }
 
   @Test
@@ -1831,8 +1892,7 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
       assertEquals("/bar", expected.getMessage());
     }
 
-    assertThatPath("/test").containsBytes(bytes)
-        .and().attribute("fileKey").is(testKey);
+    assertThatPath("/test").containsBytes(bytes).and().attribute("fileKey").is(testKey);
 
     Files.delete(path("/bar"));
     Files.createDirectory(path("/bar"));
@@ -1844,8 +1904,7 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
       assertEquals("/bar", expected.getMessage());
     }
 
-    assertThatPath("/test").containsBytes(bytes)
-        .and().attribute("fileKey").is(testKey);
+    assertThatPath("/test").containsBytes(bytes).and().attribute("fileKey").is(testKey);
   }
 
   @Test
@@ -1861,11 +1920,19 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
       Files.move(foo, foo2);
 
       assertThatPath(foo).doesNotExist();
-      assertThatPath(foo2).exists()
-          .and().attribute("lastModifiedTime").is(FileTime.fromMillis(0))
-          .and().attribute("lastAccessTime").is(FileTime.fromMillis(1))
-          .and().attribute("creationTime").is(FileTime.fromMillis(2))
-          .and().containsBytes(bytes); // do this last; it updates the access time
+      assertThatPath(foo2)
+          .exists()
+          .and()
+          .attribute("lastModifiedTime")
+          .is(FileTime.fromMillis(0))
+          .and()
+          .attribute("lastAccessTime")
+          .is(FileTime.fromMillis(1))
+          .and()
+          .attribute("creationTime")
+          .is(FileTime.fromMillis(2))
+          .and()
+          .containsBytes(bytes); // do this last; it updates the access time
     }
   }
 
@@ -1891,11 +1958,7 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
   @Test
   public void testIsSameFile_forPathFromDifferentFileSystemProvider() throws IOException {
-    Path defaultFileSystemRoot =
-        FileSystems.getDefault()
-            .getRootDirectories()
-            .iterator()
-            .next();
+    Path defaultFileSystemRoot = FileSystems.getDefault().getRootDirectories().iterator().next();
 
     assertThat(Files.isSameFile(path("/"), defaultFileSystemRoot)).isFalse();
   }
@@ -2294,8 +2357,7 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
   public void testUnsupportedFeatures() throws IOException {
     FileSystem fileSystem =
         Jimfs.newFileSystem(
-            Configuration.unix()
-                .toBuilder()
+            Configuration.unix().toBuilder()
                 .setSupportedFeatures() // none
                 .build());
 

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsWindowsLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsWindowsLikeFileSystemTest.java
@@ -23,11 +23,6 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
@@ -37,6 +32,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.regex.PatternSyntaxException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests a Windows-like file system through the public methods in {@link Files}.
@@ -50,8 +48,7 @@ public class JimfsWindowsLikeFileSystemTest extends AbstractJimfsIntegrationTest
   protected FileSystem createFileSystem() {
     return Jimfs.newFileSystem(
         "win",
-        Configuration.windows()
-            .toBuilder()
+        Configuration.windows().toBuilder()
             .setRoots("C:\\", "E:\\")
             .setAttributeViews("basic", "owner", "dos", "acl", "user")
             .build());
@@ -72,16 +69,15 @@ public class JimfsWindowsLikeFileSystemTest extends AbstractJimfsIntegrationTest
 
   @Test
   public void testPaths() {
-    assertThatPath("C:\\").isAbsolute()
-        .and().hasRootComponent("C:\\")
-        .and().hasNoNameComponents();
-    assertThatPath("foo").isRelative()
-        .and().hasNameComponents("foo");
-    assertThatPath("foo\\bar").isRelative()
-        .and().hasNameComponents("foo", "bar");
-    assertThatPath("C:\\foo\\bar\\baz").isAbsolute()
-        .and().hasRootComponent("C:\\")
-        .and().hasNameComponents("foo", "bar", "baz");
+    assertThatPath("C:\\").isAbsolute().and().hasRootComponent("C:\\").and().hasNoNameComponents();
+    assertThatPath("foo").isRelative().and().hasNameComponents("foo");
+    assertThatPath("foo\\bar").isRelative().and().hasNameComponents("foo", "bar");
+    assertThatPath("C:\\foo\\bar\\baz")
+        .isAbsolute()
+        .and()
+        .hasRootComponent("C:\\")
+        .and()
+        .hasNameComponents("foo", "bar", "baz");
   }
 
   @Test
@@ -105,57 +101,90 @@ public class JimfsWindowsLikeFileSystemTest extends AbstractJimfsIntegrationTest
 
   @Test
   public void testPaths_withSlash() {
-    assertThatPath("foo/bar").isRelative()
-        .and().hasNameComponents("foo", "bar")
-        .and().isEqualTo(path("foo\\bar"));
-    assertThatPath("C:/foo/bar/baz").isAbsolute()
-        .and().hasRootComponent("C:\\")
-        .and().hasNameComponents("foo", "bar", "baz")
-        .and().isEqualTo(path("C:\\foo\\bar\\baz"));
-    assertThatPath("C:/foo\\bar/baz").isAbsolute()
-        .and().hasRootComponent("C:\\")
-        .and().hasNameComponents("foo", "bar", "baz")
-        .and().isEqualTo(path("C:\\foo\\bar\\baz"));
+    assertThatPath("foo/bar")
+        .isRelative()
+        .and()
+        .hasNameComponents("foo", "bar")
+        .and()
+        .isEqualTo(path("foo\\bar"));
+    assertThatPath("C:/foo/bar/baz")
+        .isAbsolute()
+        .and()
+        .hasRootComponent("C:\\")
+        .and()
+        .hasNameComponents("foo", "bar", "baz")
+        .and()
+        .isEqualTo(path("C:\\foo\\bar\\baz"));
+    assertThatPath("C:/foo\\bar/baz")
+        .isAbsolute()
+        .and()
+        .hasRootComponent("C:\\")
+        .and()
+        .hasNameComponents("foo", "bar", "baz")
+        .and()
+        .isEqualTo(path("C:\\foo\\bar\\baz"));
   }
 
   @Test
   public void testPaths_resolve() {
-    assertThatPath(path("C:\\").resolve("foo\\bar")).isAbsolute()
-        .and().hasRootComponent("C:\\")
-        .and().hasNameComponents("foo", "bar");
-    assertThatPath(path("foo\\bar").resolveSibling("baz")).isRelative()
-        .and().hasNameComponents("foo", "baz");
-    assertThatPath(path("foo\\bar").resolve("C:\\one\\two")).isAbsolute()
-        .and().hasRootComponent("C:\\")
-        .and().hasNameComponents("one", "two");
+    assertThatPath(path("C:\\").resolve("foo\\bar"))
+        .isAbsolute()
+        .and()
+        .hasRootComponent("C:\\")
+        .and()
+        .hasNameComponents("foo", "bar");
+    assertThatPath(path("foo\\bar").resolveSibling("baz"))
+        .isRelative()
+        .and()
+        .hasNameComponents("foo", "baz");
+    assertThatPath(path("foo\\bar").resolve("C:\\one\\two"))
+        .isAbsolute()
+        .and()
+        .hasRootComponent("C:\\")
+        .and()
+        .hasNameComponents("one", "two");
   }
 
   @Test
   public void testPaths_normalize() {
-    assertThatPath(path("foo\\bar\\..").normalize()).isRelative()
-        .and().hasNameComponents("foo");
-    assertThatPath(path("foo\\.\\bar\\..\\baz\\test\\.\\..\\stuff").normalize()).isRelative()
-        .and().hasNameComponents("foo", "baz", "stuff");
-    assertThatPath(path("..\\..\\foo\\.\\bar").normalize()).isRelative()
-        .and().hasNameComponents("..", "..", "foo", "bar");
-    assertThatPath(path("foo\\..\\..\\bar").normalize()).isRelative()
-        .and().hasNameComponents("..", "bar");
-    assertThatPath(path("..\\.\\..").normalize()).isRelative()
-        .and().hasNameComponents("..", "..");
+    assertThatPath(path("foo\\bar\\..").normalize()).isRelative().and().hasNameComponents("foo");
+    assertThatPath(path("foo\\.\\bar\\..\\baz\\test\\.\\..\\stuff").normalize())
+        .isRelative()
+        .and()
+        .hasNameComponents("foo", "baz", "stuff");
+    assertThatPath(path("..\\..\\foo\\.\\bar").normalize())
+        .isRelative()
+        .and()
+        .hasNameComponents("..", "..", "foo", "bar");
+    assertThatPath(path("foo\\..\\..\\bar").normalize())
+        .isRelative()
+        .and()
+        .hasNameComponents("..", "bar");
+    assertThatPath(path("..\\.\\..").normalize()).isRelative().and().hasNameComponents("..", "..");
   }
 
   @Test
   public void testPaths_relativize() {
-    assertThatPath(path("C:\\foo\\bar").relativize(path("C:\\foo\\bar\\baz"))).isRelative()
-        .and().hasNameComponents("baz");
-    assertThatPath(path("C:\\foo\\bar\\baz").relativize(path("C:\\foo\\bar"))).isRelative()
-        .and().hasNameComponents("..");
-    assertThatPath(path("C:\\foo\\bar\\baz").relativize(path("C:\\foo\\baz\\bar"))).isRelative()
-        .and().hasNameComponents("..", "..", "baz", "bar");
-    assertThatPath(path("foo\\bar").relativize(path("foo"))).isRelative()
-        .and().hasNameComponents("..");
-    assertThatPath(path("foo").relativize(path("foo\\bar"))).isRelative()
-        .and().hasNameComponents("bar");
+    assertThatPath(path("C:\\foo\\bar").relativize(path("C:\\foo\\bar\\baz")))
+        .isRelative()
+        .and()
+        .hasNameComponents("baz");
+    assertThatPath(path("C:\\foo\\bar\\baz").relativize(path("C:\\foo\\bar")))
+        .isRelative()
+        .and()
+        .hasNameComponents("..");
+    assertThatPath(path("C:\\foo\\bar\\baz").relativize(path("C:\\foo\\baz\\bar")))
+        .isRelative()
+        .and()
+        .hasNameComponents("..", "..", "baz", "bar");
+    assertThatPath(path("foo\\bar").relativize(path("foo")))
+        .isRelative()
+        .and()
+        .hasNameComponents("..");
+    assertThatPath(path("foo").relativize(path("foo\\bar")))
+        .isRelative()
+        .and()
+        .hasNameComponents("bar");
 
     try {
       Path unused = path("C:\\foo\\bar").relativize(path("bar"));
@@ -184,15 +213,23 @@ public class JimfsWindowsLikeFileSystemTest extends AbstractJimfsIntegrationTest
 
   @Test
   public void testPaths_toAbsolutePath() {
-    assertThatPath(path("C:\\foo\\bar").toAbsolutePath()).isAbsolute()
-        .and().hasRootComponent("C:\\")
-        .and().hasNameComponents("foo", "bar")
-        .and().isEqualTo(path("C:\\foo\\bar"));
+    assertThatPath(path("C:\\foo\\bar").toAbsolutePath())
+        .isAbsolute()
+        .and()
+        .hasRootComponent("C:\\")
+        .and()
+        .hasNameComponents("foo", "bar")
+        .and()
+        .isEqualTo(path("C:\\foo\\bar"));
 
-    assertThatPath(path("foo\\bar").toAbsolutePath()).isAbsolute()
-        .and().hasRootComponent("C:\\")
-        .and().hasNameComponents("work", "foo", "bar")
-        .and().isEqualTo(path("C:\\work\\foo\\bar"));
+    assertThatPath(path("foo\\bar").toAbsolutePath())
+        .isAbsolute()
+        .and()
+        .hasRootComponent("C:\\")
+        .and()
+        .hasNameComponents("work", "foo", "bar")
+        .and()
+        .isEqualTo(path("C:\\work\\foo\\bar"));
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/OwnerAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/OwnerAttributeProviderTest.java
@@ -20,14 +20,12 @@ import static com.google.common.jimfs.UserLookupService.createUserPrincipal;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.attribute.FileOwnerAttributeView;
 import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link OwnerAttributeProvider}.

--- a/jimfs/src/test/java/com/google/common/jimfs/PathNormalizationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathNormalizationTest.java
@@ -26,12 +26,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
-
+import java.util.regex.Pattern;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.regex.Pattern;
 
 /**
  * Tests for {@link PathNormalization}.
@@ -305,18 +303,14 @@ public class PathNormalizationTest {
     assertNormalizedPatternMatches("AM\u00c9LIE", "AME\u0301LIE");
   }
 
-  /**
-   * Asserts that the given strings normalize to the same string using the current normalizer.
-   */
+  /** Asserts that the given strings normalize to the same string using the current normalizer. */
   private void assertNormalizedEqual(String first, String second) {
     assertEquals(
         PathNormalization.normalize(first, normalizations),
         PathNormalization.normalize(second, normalizations));
   }
 
-  /**
-   * Asserts that the given strings normalize to different strings using the current normalizer.
-   */
+  /** Asserts that the given strings normalize to different strings using the current normalizer. */
   private void assertNormalizedUnequal(String first, String second) {
     assertNotEquals(
         PathNormalization.normalize(first, normalizations),

--- a/jimfs/src/test/java/com/google/common/jimfs/PathServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathServiceTest.java
@@ -22,14 +22,12 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link PathService}.
@@ -51,47 +49,63 @@ public class PathServiceTest {
 
   @Test
   public void testPathCreation() {
-    assertAbout(paths()).that(service.emptyPath())
+    assertAbout(paths())
+        .that(service.emptyPath())
         .hasRootComponent(null)
-        .and().hasNameComponents("");
+        .and()
+        .hasNameComponents("");
 
-    assertAbout(paths()).that(service.createRoot(service.name("/")))
+    assertAbout(paths())
+        .that(service.createRoot(service.name("/")))
         .isAbsolute()
-        .and().hasRootComponent("/")
-        .and().hasNoNameComponents();
+        .and()
+        .hasRootComponent("/")
+        .and()
+        .hasNoNameComponents();
 
-    assertAbout(paths()).that(service.createFileName(service.name("foo")))
+    assertAbout(paths())
+        .that(service.createFileName(service.name("foo")))
         .hasRootComponent(null)
-        .and().hasNameComponents("foo");
+        .and()
+        .hasNameComponents("foo");
 
     JimfsPath relative = service.createRelativePath(service.names(ImmutableList.of("foo", "bar")));
-    assertAbout(paths()).that(relative)
+    assertAbout(paths())
+        .that(relative)
         .hasRootComponent(null)
-        .and().hasNameComponents("foo", "bar");
+        .and()
+        .hasNameComponents("foo", "bar");
 
     JimfsPath absolute =
         service.createPath(service.name("/"), service.names(ImmutableList.of("foo", "bar")));
-    assertAbout(paths()).that(absolute)
+    assertAbout(paths())
+        .that(absolute)
         .isAbsolute()
-        .and().hasRootComponent("/")
-        .and().hasNameComponents("foo", "bar");
+        .and()
+        .hasRootComponent("/")
+        .and()
+        .hasNameComponents("foo", "bar");
   }
 
   @Test
   public void testPathCreation_emptyPath() {
     // normalized to empty path with single empty string name
-    assertAbout(paths()).that(service.createPath(null, ImmutableList.<Name>of()))
+    assertAbout(paths())
+        .that(service.createPath(null, ImmutableList.<Name>of()))
         .hasRootComponent(null)
-        .and().hasNameComponents("");
+        .and()
+        .hasNameComponents("");
   }
 
   @Test
   public void testPathCreation_parseIgnoresEmptyString() {
     // if the empty string wasn't ignored, the resulting path would be "/foo" since the empty
     // string would be joined with foo
-    assertAbout(paths()).that(service.parsePath("", "foo"))
+    assertAbout(paths())
+        .that(service.parsePath("", "foo"))
         .hasRootComponent(null)
-        .and().hasNameComponents("foo");
+        .and()
+        .hasNameComponents("foo");
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
@@ -123,9 +123,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
 
   /** Asserts that the path has no name components. */
   public PathSubject hasNoNameComponents() {
-    if (actual().getNameCount() != 0) {
-      fail("has no name components");
-    }
+    check("getNameCount()").that(actual().getNameCount()).isEqualTo(0);
     return this;
   }
 

--- a/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
@@ -62,9 +62,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return actual().getFileSystem().getPath(path);
   }
 
-  /**
-   * Returns this, for readability of chained assertions.
-   */
+  /** Returns this, for readability of chained assertions. */
   public PathSubject and() {
     return this;
   }
@@ -81,26 +79,22 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return newSubject;
   }
 
-  /**
-   * Do not follow links when looking up the path.
-   */
+  /** Do not follow links when looking up the path. */
   public PathSubject noFollowLinks() {
     this.linkOptions = NOFOLLOW_LINKS;
     return this;
   }
 
   /**
-   * Set the given charset to be used when reading the file at this path as text. Default charset
-   * if not set is UTF-8.
+   * Set the given charset to be used when reading the file at this path as text. Default charset if
+   * not set is UTF-8.
    */
   public PathSubject withCharset(Charset charset) {
     this.charset = checkNotNull(charset);
     return this;
   }
 
-  /**
-   * Asserts that the path is absolute (it has a root component).
-   */
+  /** Asserts that the path is absolute (it has a root component). */
   public PathSubject isAbsolute() {
     if (!actual().isAbsolute()) {
       fail("is absolute");
@@ -108,9 +102,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path is relative (it has no root component).
-   */
+  /** Asserts that the path is relative (it has no root component). */
   public PathSubject isRelative() {
     if (actual().isAbsolute()) {
       fail("is relative");
@@ -118,9 +110,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path has the given root component.
-   */
+  /** Asserts that the path has the given root component. */
   public PathSubject hasRootComponent(@Nullable String root) {
     Path rootComponent = actual().getRoot();
     if (root == null && rootComponent != null) {
@@ -131,9 +121,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path has no name components.
-   */
+  /** Asserts that the path has no name components. */
   public PathSubject hasNoNameComponents() {
     if (actual().getNameCount() != 0) {
       fail("has no name components");
@@ -141,9 +129,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path has the given name components.
-   */
+  /** Asserts that the path has the given name components. */
   public PathSubject hasNameComponents(String... names) {
     ImmutableList.Builder<String> builder = ImmutableList.builder();
     for (Path name : actual()) {
@@ -156,9 +142,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path matches the given syntax and pattern.
-   */
+  /** Asserts that the path matches the given syntax and pattern. */
   public PathSubject matches(String syntaxAndPattern) {
     PathMatcher matcher = actual().getFileSystem().getPathMatcher(syntaxAndPattern);
     if (!matcher.matches(actual())) {
@@ -167,9 +151,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path does not match the given syntax and pattern.
-   */
+  /** Asserts that the path does not match the given syntax and pattern. */
   public PathSubject doesNotMatch(String syntaxAndPattern) {
     PathMatcher matcher = actual().getFileSystem().getPathMatcher(syntaxAndPattern);
     if (matcher.matches(actual())) {
@@ -178,9 +160,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path exists.
-   */
+  /** Asserts that the path exists. */
   public PathSubject exists() {
     if (!Files.exists(actual(), linkOptions)) {
       fail("exist");
@@ -191,9 +171,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path does not exist.
-   */
+  /** Asserts that the path does not exist. */
   public PathSubject doesNotExist() {
     if (!Files.notExists(actual(), linkOptions)) {
       fail("does not exist");
@@ -204,9 +182,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path is a directory.
-   */
+  /** Asserts that the path is a directory. */
   public PathSubject isDirectory() {
     exists(); // check for directoryness should imply check for existence
 
@@ -216,9 +192,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path is a regular file.
-   */
+  /** Asserts that the path is a regular file. */
   public PathSubject isRegularFile() {
     exists(); // check for regular fileness should imply check for existence
 
@@ -228,9 +202,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path is a symbolic link.
-   */
+  /** Asserts that the path is a symbolic link. */
   public PathSubject isSymbolicLink() {
     exists(); // check for symbolic linkness should imply check for existence
 
@@ -240,9 +212,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path, which is a symbolic link, has the given path as a target.
-   */
+  /** Asserts that the path, which is a symbolic link, has the given path as a target. */
   public PathSubject withTarget(String targetPath) throws IOException {
     if (!Files.readSymbolicLink(actual()).equals(toPath(targetPath))) {
       fail("symbolic link target is", targetPath);
@@ -251,8 +221,8 @@ public final class PathSubject extends Subject<PathSubject, Path> {
   }
 
   /**
-   * Asserts that the file the path points to exists and has the given number of links to it.
-   * Fails on a file system that does not support the "unix" view.
+   * Asserts that the file the path points to exists and has the given number of links to it. Fails
+   * on a file system that does not support the "unix" view.
    */
   public PathSubject hasLinkCount(int count) throws IOException {
     exists();
@@ -264,16 +234,12 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path resolves to the same file as the given path.
-   */
+  /** Asserts that the path resolves to the same file as the given path. */
   public PathSubject isSameFileAs(String path) throws IOException {
     return isSameFileAs(toPath(path));
   }
 
-  /**
-   * Asserts that the path resolves to the same file as the given path.
-   */
+  /** Asserts that the path resolves to the same file as the given path. */
   public PathSubject isSameFileAs(Path path) throws IOException {
     if (!Files.isSameFile(actual(), path)) {
       fail("is same file as", path);
@@ -281,9 +247,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the path does not resolve to the same file as the given path.
-   */
+  /** Asserts that the path does not resolve to the same file as the given path. */
   public PathSubject isNotSameFileAs(String path) throws IOException {
     if (Files.isSameFile(actual(), toPath(path))) {
       fail("is not same file as", path);
@@ -291,9 +255,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the directory has no children.
-   */
+  /** Asserts that the directory has no children. */
   public PathSubject hasNoChildren() throws IOException {
     isDirectory();
 
@@ -305,9 +267,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the directory has children with the given names, in the given order.
-   */
+  /** Asserts that the directory has children with the given names, in the given order. */
   public PathSubject hasChildren(String... children) throws IOException {
     isDirectory();
 
@@ -329,9 +289,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the file has the given size.
-   */
+  /** Asserts that the file has the given size. */
   public PathSubject hasSize(long size) throws IOException {
     if (Files.size(actual()) != size) {
       fail("has size", size);
@@ -339,9 +297,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Asserts that the file is a regular file containing no bytes.
-   */
+  /** Asserts that the file is a regular file containing no bytes. */
   public PathSubject containsNoBytes() throws IOException {
     return containsBytes(new byte[0]);
   }
@@ -357,9 +313,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return containsBytes(realBytes);
   }
 
-  /**
-   * Asserts that the file is a regular file containing exactly the given bytes.
-   */
+  /** Asserts that the file is a regular file containing exactly the given bytes. */
   public PathSubject containsBytes(byte[] bytes) throws IOException {
     isRegularFile();
     hasSize(bytes.length);
@@ -410,9 +364,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Returns an object for making assertions about the given attribute.
-   */
+  /** Returns an object for making assertions about the given attribute. */
   public Attribute attribute(final String attribute) {
     return new Attribute() {
       @Override
@@ -448,24 +400,16 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     }
   }
 
-  /**
-   * Interface for assertions about a file attribute.
-   */
+  /** Interface for assertions about a file attribute. */
   public interface Attribute {
 
-    /**
-     * Asserts that the value of this attribute is equal to the given value.
-     */
+    /** Asserts that the value of this attribute is equal to the given value. */
     Attribute is(Object value) throws IOException;
 
-    /**
-     * Asserts that the value of this attribute is not equal to the given value.
-     */
+    /** Asserts that the value of this attribute is not equal to the given value. */
     Attribute isNot(Object value) throws IOException;
 
-    /**
-     * Returns the path subject for further chaining.
-     */
+    /** Returns the path subject for further chaining. */
     PathSubject and();
   }
 }

--- a/jimfs/src/test/java/com/google/common/jimfs/PathTester.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathTester.java
@@ -27,14 +27,11 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
-
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public final class PathTester {
 
   private final PathService pathService;
@@ -95,9 +92,7 @@ public final class PathTester {
       assertEquals(names.get(i), path.getName(i).toString());
       // don't test individual names if this is an individual name
       if (names.size() > 1) {
-        new PathTester(pathService, names.get(i))
-            .names(names.get(i))
-            .test(path.getName(i));
+        new PathTester(pathService, names.get(i)).names(names.get(i)).test(path.getName(i));
       }
     }
     if (names.size() > 0) {
@@ -105,9 +100,7 @@ public final class PathTester {
       assertEquals(fileName, path.getFileName().toString());
       // don't test individual names if this is an individual name
       if (names.size() > 1) {
-        new PathTester(pathService, fileName)
-            .names(fileName)
-            .test(path.getFileName());
+        new PathTester(pathService, fileName).names(fileName).test(path.getFileName());
       }
     }
   }
@@ -144,7 +137,8 @@ public final class PathTester {
               .subList(1, path.getNameCount());
 
       new PathTester(pathService, Joiner.on('/').join(startNames))
-          .names(startNames).test(startSubpath);
+          .names(startNames)
+          .test(startSubpath);
 
       Path endSubpath = path.subpath(0, path.getNameCount() - 1);
       List<String> endNames =

--- a/jimfs/src/test/java/com/google/common/jimfs/PathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathTypeTest.java
@@ -21,14 +21,11 @@ import static com.google.common.jimfs.PathType.ParseResult;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
-
+import java.net.URI;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.net.URI;
-
-import javax.annotation.Nullable;
 
 /**
  * Tests for {@link PathType}.
@@ -110,9 +107,7 @@ public class PathTypeTest {
     assertThat(parsedUri.names()).containsExactlyElementsIn(result.names()).inOrder();
   }
 
-  /**
-   * Arbitrary path type with $ as the root, / as the separator and \ as an alternate separator.
-   */
+  /** Arbitrary path type with $ as the root, / as the separator and \ as an alternate separator. */
   private static final class FakePathType extends PathType {
 
     protected FakePathType() {

--- a/jimfs/src/test/java/com/google/common/jimfs/PollingWatchServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PollingWatchServiceTest.java
@@ -28,13 +28,6 @@ import com.google.common.jimfs.AbstractWatchService.Event;
 import com.google.common.jimfs.AbstractWatchService.Key;
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.Uninterruptibles;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -45,6 +38,11 @@ import java.nio.file.WatchKey;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link PollingWatchService}.
@@ -65,7 +63,8 @@ public class PollingWatchServiceTest {
             fs.getDefaultView(),
             fs.getPathService(),
             new FileSystemState(Runnables.doNothing()),
-            4, MILLISECONDS);
+            4,
+            MILLISECONDS);
   }
 
   @After

--- a/jimfs/src/test/java/com/google/common/jimfs/PosixAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PosixAttributeProviderTest.java
@@ -24,17 +24,15 @@ import static org.junit.Assert.assertNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link PosixAttributeProvider}.

--- a/jimfs/src/test/java/com/google/common/jimfs/RegexGlobMatcherTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/RegexGlobMatcherTest.java
@@ -19,15 +19,13 @@ package com.google.common.jimfs;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.util.regex.Pattern;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link PathMatcher} instances created by {@link GlobToRegex}.

--- a/jimfs/src/test/java/com/google/common/jimfs/RegularFileBlocksTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/RegularFileBlocksTest.java
@@ -19,7 +19,6 @@ package com.google.common.jimfs;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.primitives.Bytes;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/jimfs/src/test/java/com/google/common/jimfs/RegularFileTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/RegularFileTest.java
@@ -27,10 +27,6 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -40,6 +36,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Tests for {@link RegularFile} and by extension for {@link HeapDisk}. These tests test files
@@ -100,34 +98,23 @@ public class RegularFileTest {
           .toList();
 
   /**
-   * Different strategies for handling reuse of disks and/or files between tests, intended to
-   * ensure that {@link HeapDisk} operates properly in a variety of usage states including newly
-   * created, having created files that have not been deleted yet, having created files that have
-   * been deleted, and having created files some of which have been deleted and some of which have
-   * not.
+   * Different strategies for handling reuse of disks and/or files between tests, intended to ensure
+   * that {@link HeapDisk} operates properly in a variety of usage states including newly created,
+   * having created files that have not been deleted yet, having created files that have been
+   * deleted, and having created files some of which have been deleted and some of which have not.
    */
   public enum ReuseStrategy {
-    /**
-     * Creates a new disk for each test.
-     */
+    /** Creates a new disk for each test. */
     NEW_DISK,
-    /**
-     * Retains files after each test, forcing new blocks to be allocated.
-     */
+    /** Retains files after each test, forcing new blocks to be allocated. */
     KEEP_FILES,
-    /**
-     * Deletes files after each test, allowing caching to be used if enabled.
-     */
+    /** Deletes files after each test, allowing caching to be used if enabled. */
     DELETE_FILES,
-    /**
-     * Randomly keeps or deletes a file after each test.
-     */
+    /** Randomly keeps or deletes a file after each test. */
     KEEP_OR_DELETE_FILES
   }
 
-  /**
-   * Configuration for a set of test cases.
-   */
+  /** Configuration for a set of test cases. */
   public static final class TestConfiguration {
 
     private final int blockSize;
@@ -181,9 +168,7 @@ public class RegularFileTest {
     }
   }
 
-  /**
-   * Actual test cases for testing RegularFiles.
-   */
+  /** Actual test cases for testing RegularFiles. */
   public static class RegularFileTestRunner extends TestCase {
 
     private final TestConfiguration configuration;

--- a/jimfs/src/test/java/com/google/common/jimfs/TestAttributeProvider.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/TestAttributeProvider.java
@@ -20,19 +20,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.IOException;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public final class TestAttributeProvider extends AttributeProvider {
 
   private static final ImmutableSet<String> ATTRIBUTES = ImmutableSet.of("foo", "bar", "baz");

--- a/jimfs/src/test/java/com/google/common/jimfs/TestAttributeView.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/TestAttributeView.java
@@ -19,9 +19,7 @@ package com.google.common.jimfs;
 import java.io.IOException;
 import java.nio.file.attribute.BasicFileAttributeView;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public interface TestAttributeView extends BasicFileAttributeView {
 
   TestAttributes readAttributes() throws IOException;

--- a/jimfs/src/test/java/com/google/common/jimfs/TestAttributes.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/TestAttributes.java
@@ -18,9 +18,7 @@ package com.google.common.jimfs;
 
 import java.nio.file.attribute.BasicFileAttributes;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public interface TestAttributes extends BasicFileAttributes {
 
   String foo();

--- a/jimfs/src/test/java/com/google/common/jimfs/TestUtils.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/TestUtils.java
@@ -20,7 +20,6 @@ import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 import static org.junit.Assert.assertFalse;
 
 import com.google.common.collect.ImmutableList;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.DirectoryStream;
@@ -33,9 +32,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-/**
- * @author Colin Decker
- */
+/** @author Colin Decker */
 public final class TestUtils {
 
   private TestUtils() {}
@@ -83,12 +80,9 @@ public final class TestUtils {
     return result;
   }
 
-  /**
-   * Returns a number of permutations of the given path that should all locate the same file.
-   */
+  /** Returns a number of permutations of the given path that should all locate the same file. */
   public static Iterable<Path> permutations(Path path) throws IOException {
-    Path workingDir =
-        path.getFileSystem().getPath("").toRealPath();
+    Path workingDir = path.getFileSystem().getPath("").toRealPath();
     boolean directory = Files.isDirectory(path);
 
     Set<Path> results = new HashSet<>();
@@ -107,12 +101,9 @@ public final class TestUtils {
             && !fileName.toString().equals(".")
             && !fileName.toString().equals("..")) {
           results.add(p.resolve("..").resolve(fileName));
-          results.add(
-              p.resolve("..").resolve(".").resolve(fileName));
-          results.add(
-              p.resolve("..").resolve(".").resolve(fileName).resolve("."));
-          results.add(
-              p.resolve(".").resolve("..").resolve(".").resolve(fileName));
+          results.add(p.resolve("..").resolve(".").resolve(fileName));
+          results.add(p.resolve("..").resolve(".").resolve(fileName).resolve("."));
+          results.add(p.resolve(".").resolve("..").resolve(".").resolve(fileName));
         }
       }
 
@@ -122,10 +113,8 @@ public final class TestUtils {
             Path childName = child.getFileName();
             for (Path p : ImmutableList.copyOf(results)) {
               results.add(p.resolve(childName).resolve(".."));
-              results.add(
-                  p.resolve(childName).resolve(".").resolve(".").resolve(".."));
-              results.add(
-                  p.resolve(childName).resolve("..").resolve("."));
+              results.add(p.resolve(childName).resolve(".").resolve(".").resolve(".."));
+              results.add(p.resolve(childName).resolve("..").resolve("."));
               results.add(
                   p.resolve(childName).resolve("..").resolve(childName).resolve(".").resolve(".."));
             }

--- a/jimfs/src/test/java/com/google/common/jimfs/UnixAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UnixAttributeProviderTest.java
@@ -21,14 +21,12 @@ import static com.google.common.jimfs.UserLookupService.createUserPrincipal;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link UnixAttributeProvider}.

--- a/jimfs/src/test/java/com/google/common/jimfs/UnixPathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UnixPathTypeTest.java
@@ -24,13 +24,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
-
+import java.net.URI;
+import java.nio.file.InvalidPathException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.net.URI;
-import java.nio.file.InvalidPathException;
 
 /**
  * Tests for {@link UnixPathType}.

--- a/jimfs/src/test/java/com/google/common/jimfs/UrlTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UrlTest.java
@@ -23,11 +23,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.common.io.Resources;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -36,6 +31,9 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests that {@link URL} instances can be created and used from jimfs URIs.
@@ -71,8 +69,7 @@ public class UrlTest {
     Files.createDirectory(path.resolve("c"));
 
     URL url = path.toUri().toURL();
-    assertThat(Resources.asCharSource(url, UTF_8).read())
-        .isEqualTo("a.txt\nb.txt\nc\n");
+    assertThat(Resources.asCharSource(url, UTF_8).read()).isEqualTo("a.txt\nb.txt\nc\n");
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/UserDefinedAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UserDefinedAttributeProviderTest.java
@@ -92,7 +92,7 @@ public class UserDefinedAttributeProviderTest
     view.write("b1", ByteBuffer.wrap(b1));
     view.write("b2", ByteBuffer.wrap(b2));
 
-    assertThat(view.list()).containsAllOf("b1", "b2");
+    assertThat(view.list()).containsAtLeast("b1", "b2");
     assertThat(file.getAttributeKeys()).containsExactly("user:b1", "user:b2");
 
     assertThat(view.size("b1")).isEqualTo(3);

--- a/jimfs/src/test/java/com/google/common/jimfs/UserDefinedAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UserDefinedAttributeProviderTest.java
@@ -22,16 +22,14 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Arrays;
 import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link UserDefinedAttributeProvider}.

--- a/jimfs/src/test/java/com/google/common/jimfs/UserLookupServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UserLookupServiceTest.java
@@ -19,15 +19,14 @@ package com.google.common.jimfs;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.IOException;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.attribute.UserPrincipalNotFoundException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link UserLookupService}.

--- a/jimfs/src/test/java/com/google/common/jimfs/WatchServiceConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/WatchServiceConfigurationTest.java
@@ -20,17 +20,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.google.common.truth.Truth;
-
+import java.io.IOException;
+import java.nio.file.WatchService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.io.IOException;
-import java.nio.file.WatchService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link WatchServiceConfiguration}.
@@ -68,8 +64,8 @@ public class WatchServiceConfigurationTest {
 
   @Test
   public void testDefaultConfig() {
-    WatchService watchService = WatchServiceConfiguration.DEFAULT
-        .newWatchService(fs.getDefaultView(), fs.getPathService());
+    WatchService watchService =
+        WatchServiceConfiguration.DEFAULT.newWatchService(fs.getDefaultView(), fs.getPathService());
     assertThat(watchService).isInstanceOf(PollingWatchService.class);
 
     PollingWatchService pollingWatchService = (PollingWatchService) watchService;

--- a/jimfs/src/test/java/com/google/common/jimfs/WindowsPathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/WindowsPathTypeTest.java
@@ -24,13 +24,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
-
+import java.net.URI;
+import java.nio.file.InvalidPathException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.net.URI;
-import java.nio.file.InvalidPathException;
 
 /**
  * Tests for {@link WindowsPathType}.

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>0.40</version>
+        <version>0.44</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Run google-java-format over all of JimFS.

RELNOTES=Run google-java-format over all of JimFS.

4a8cba01453c4decb814845530e29303d71dba4c

-------

<p> Migrate Truth subjects from a manual "test and fail" approach to one using Subject.check(...).

Before:
  if (actual().foo() != expected) {
    fail("has foo", expected);
  }

After:
  check("foo()").that(actual().foo()).isEqualTo(expected);

This CL changes the format of the failure message. The new message will typically contain the same information as the old, but if some is missing, let us know, and consider adding a test.

The overload of check(...) used by this CL was added in Truth 0.40.

33fba3f1e563874ffedae65159ac8c271f39916f

-------

<p> Update to Truth 0.44.

6b0bffb78d1e49c703447eb4de60f54b6a546647

-------

<p> Migrate from containsAllOf to containsAtLeast.

The two behave identically, and containsAllOf is being removed.

e74abb3bd60e96f896e7e9b1428ef638eb18700a

-------

<p> Migrate from assertThat(foo).named("foo") to assertWithMessage("foo").that(foo).

(The exact change is slightly different in some cases, like when using custom subjects or check(), but it's always a migration from named(...) to [assert]WithMessage(...).)

named(...) is being removed.

This CL may slightly modify the failure messages produced, but all the old information will still be present.

a440fc1e8a436b3bb412fa45b13ba45fe79d43df