### PR TITLE
Moe Sync

### DIFF
--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
@@ -1813,26 +1813,19 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
     Object fooKey = getFileKey("/foo");
 
     Files.move(path("/foo"), path("/bar"));
-    assertThatPath("/foo")
-        .doesNotExist()
-        .andThat("/bar")
-        .containsBytes(bytes)
-        .and()
-        .attribute("fileKey")
-        .is(fooKey);
+    assertThatPath("/foo").doesNotExist();
+    assertThatPath("/bar").containsBytes(bytes).and().attribute("fileKey").is(fooKey);
 
     Files.createDirectory(path("/foo"));
     Files.move(path("/bar"), path("/foo/bar"));
 
-    assertThatPath("/bar").doesNotExist().andThat("/foo/bar").isRegularFile();
+    assertThatPath("/bar").doesNotExist();
+    assertThatPath("/foo/bar").isRegularFile();
 
     Files.move(path("/foo"), path("/baz"));
-    assertThatPath("/foo")
-        .doesNotExist()
-        .andThat("/baz")
-        .isDirectory()
-        .andThat("/baz/bar")
-        .isRegularFile();
+    assertThatPath("/foo").doesNotExist();
+    assertThatPath("/baz").isDirectory();
+    assertThatPath("/baz/bar").isRegularFile();
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
@@ -73,7 +73,7 @@ public final class PathSubject extends Subject<PathSubject, Path> {
    */
   // TODO(cgruber): Talk to cdecker about removing this as an anti-pattern.
   public PathSubject andThat(String path, LinkOption... linkOptions) {
-    PathSubject newSubject = check().about(paths()).that(toPath(path));
+    PathSubject newSubject = check("path(%s", path).about(paths()).that(toPath(path));
     if (linkOptions.length != 0) {
       newSubject = newSubject.noFollowLinks();
     }

--- a/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
@@ -68,18 +68,6 @@ public final class PathSubject extends Subject<PathSubject, Path> {
     return this;
   }
 
-  /**
-   * Returns a new subject for asserting against a different path or with different link options.
-   */
-  // TODO(cgruber): Talk to cdecker about removing this as an anti-pattern.
-  public PathSubject andThat(String path, LinkOption... linkOptions) {
-    PathSubject newSubject = check("path(%s", path).about(paths()).that(toPath(path));
-    if (linkOptions.length != 0) {
-      newSubject = newSubject.noFollowLinks();
-    }
-    return newSubject;
-  }
-
   /** Do not follow links when looking up the path. */
   public PathSubject noFollowLinks() {
     this.linkOptions = NOFOLLOW_LINKS;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate Truth Subjects from no-arg check() to the overload that accepts a description.

The overload that accepts a description generally produces better failure messages:
- The first line of the message it produces is something like: "value of: myProto.getResponse()" (where "getResponse()" is taken from the provided description)
- The last line of the message it produces is something like: "myProto was: response: query was throttled" (the full value of myProto)
- And the existing text goes in between.

Additional motivation: We are deleting the no-arg overload externally (and probably internally thereafter).

951ac2037c8bd3209e78ab897fc5dfe41ab934dd

-------

<p> Remove PathSubject.andThat().

35d8d17d293da8ed470970a3f92cf9935947846e