### PR TITLE
Fix Handler.getHostAddress() performance issue

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/Handler.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Handler.java
@@ -19,6 +19,7 @@ package com.google.common.jimfs;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
@@ -76,5 +77,16 @@ public final class Handler extends URLStreamHandler {
   @Override
   protected URLConnection openConnection(URL url) throws IOException {
     return new PathURLConnection(url);
+  }
+
+  /**
+   * jimfs uses the URI host to specify the name of the file system being used. However, in the
+   * default implementation of getHostAddress(URL), a non-null host would cause an attempt to
+   * look up the IP address, causing a slowdown on calling equals/hashCode methods on the URL
+   * object.
+   */
+  @Override
+  protected synchronized InetAddress getHostAddress(URL url) {
+    return null;
   }
 }


### PR DESCRIPTION
This issue popped up when I had used URLs pointing at jimfs filesystems as HashMap keys in a project. In short, a non-null-or-empty host caused the URLStreamHandler to perform IP lookup requests for jimfs filesystem names declared as the host in said URL; with this patch, this is no longer the case.