### PR TITLE
Moe Sync

### DIFF
--- a/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
@@ -215,8 +215,15 @@ public class DirectoryTest {
     root.link(Name.simple("bar"), regularFile(10));
     root.link(Name.simple("abc"), regularFile(10));
 
+    /*
+     * If we inline this into the assertThat call below, javac resolves it to assertThat(SortedSet),
+     * which isn't available publicly. Our @GoogleInternal checks consider that to be an error, even
+     * though the code will compile fine externally by resolving to assertThat(Iterable) instead. So
+     * we avoid that by assigning to a non-SortedSet type here.
+     */
+    ImmutableSet<Name> snapshot = root.snapshot();
     // does not include . or .. and is sorted by the name
-    assertThat(root.snapshot())
+    assertThat(snapshot)
         .containsExactly(Name.simple("abc"), Name.simple("bar"), Name.simple("foo"));
   }
 

--- a/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
@@ -224,7 +224,8 @@ public class DirectoryTest {
     ImmutableSet<Name> snapshot = root.snapshot();
     // does not include . or .. and is sorted by the name
     assertThat(snapshot)
-        .containsExactly(Name.simple("abc"), Name.simple("bar"), Name.simple("foo"));
+        .containsExactly(Name.simple("abc"), Name.simple("bar"), Name.simple("foo"))
+        .inOrder();
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
  *
  * @author Colin Decker
  */
-public final class PathSubject extends Subject<PathSubject, Path> {
+public final class PathSubject extends Subject {
 
   /** Returns the subject factory for doing assertions on paths. */
   public static Subject.Factory<PathSubject, Path> paths() {

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>0.44</version>
+        <version>0.45</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix internal build breakage from making assertThat(SortedSet) @GoogleInternal.

(https://github.com/google/truth/issues/556)

60144da41441d6b51b1c30a09e2bf9730ea9c7b8

-------

<p> Assert that snapshot elements are ordered, as suggested by the comment.

f6527157ef6e06f622ee20f65674ba96a557d8fe

-------

<p> Update to Truth 0.45, and address deprecations.

Renames may include:
- containsAllOf => containsAtLeast
- containsAllIn => containsAtLeastElementsIn
- isSameAs => isSameInstanceAs
- isOrdered => isInOrder
- isStrictlyOrdered => isInStrictOrder

The other major change is to change custom subjects to extend raw Subject instead of supplying type parameters. The type parameters are being removed from Subject. This CL will temporarily produce rawtypes warnings, which will go away when I remove the type parameters (as soon as this batch of CLs is submitted).

Some CLs in this batch also migrate calls away from actualAsString(). Its literal replacement is `"<" + actual + ">"` (unless an object overrides actualCustomStringRepresentation()), but usually I've made a larger change, such as switching from an old-style "Not true that..." failure message to one generated with the Fact API. In that case, the new code usually contains a direct reference to this.actual (a field that I occasionally had to create). Another larger change I sometimes made is to switch from a manual check-and-fail approach to instead use check(...). And sometimes I just remove a withMessage() call that's no longer necessary now that the code uses check(...), or I introduce a check(...) call. (An assertion made with check(...) automatically includes the actual value from the original subject, so there's no need to set it again with withMessage().)

Finally, there's one CL in this batch in which I migrate a Correspondence subclass to instead use Correspondence.from.

0988a4514f9345d91320f762da0e2eb8b7584988