### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: java
 
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 install: mvn install -U -DskipTests=true
 

--- a/jimfs/pom.xml
+++ b/jimfs/pom.xml
@@ -60,6 +60,11 @@
       <artifactId>jsr305</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-compat-qual</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/jimfs/pom.xml
+++ b/jimfs/pom.xml
@@ -52,7 +52,7 @@
     <!-- Compile-time dependencies -->
     <dependency>
       <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
+      <artifactId>auto-service-annotations</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/jimfs/src/main/java/com/google/common/jimfs/AbstractWatchService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AbstractWatchService.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Abstract implementation of {@link WatchService}. Provides the means for registering and managing
@@ -90,14 +90,14 @@ abstract class AbstractWatchService implements WatchService {
     return ImmutableList.copyOf(queue);
   }
 
-  @Nullable
+  @NullableDecl
   @Override
   public WatchKey poll() {
     checkOpen();
     return check(queue.poll());
   }
 
-  @Nullable
+  @NullableDecl
   @Override
   public WatchKey poll(long timeout, TimeUnit unit) throws InterruptedException {
     checkOpen();
@@ -111,8 +111,8 @@ abstract class AbstractWatchService implements WatchService {
   }
 
   /** Returns the given key, throwing an exception if it's the poison. */
-  @Nullable
-  private WatchKey check(@Nullable WatchKey key) {
+  @NullableDecl
+  private WatchKey check(@NullableDecl WatchKey key) {
     if (key == poison) {
       // ensure other blocking threads get the poison
       queue.offer(poison);
@@ -142,9 +142,9 @@ abstract class AbstractWatchService implements WatchService {
     private final Kind<T> kind;
     private final int count;
 
-    @Nullable private final T context;
+    @NullableDecl private final T context;
 
-    public Event(Kind<T> kind, int count, @Nullable T context) {
+    public Event(Kind<T> kind, int count, @NullableDecl T context) {
       this.kind = checkNotNull(kind);
       checkArgument(count >= 0, "count (%s) must be non-negative", count);
       this.count = count;
@@ -161,7 +161,7 @@ abstract class AbstractWatchService implements WatchService {
       return count;
     }
 
-    @Nullable
+    @NullableDecl
     @Override
     public T context() {
       return context;
@@ -214,7 +214,7 @@ abstract class AbstractWatchService implements WatchService {
 
     public Key(
         AbstractWatchService watcher,
-        @Nullable Watchable watchable,
+        @NullableDecl Watchable watchable,
         Iterable<? extends WatchEvent.Kind<?>> subscribedTypes) {
       this.watcher = checkNotNull(watcher);
       this.watchable = watchable; // nullable for Watcher poison

--- a/jimfs/src/main/java/com/google/common/jimfs/AclAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AclAttributeProvider.java
@@ -29,7 +29,7 @@ import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Attribute provider that provides the {@link AclFileAttributeView} ("acl").
@@ -71,7 +71,7 @@ final class AclAttributeProvider extends AttributeProvider {
     return ImmutableMap.of("acl:acl", acl);
   }
 
-  @Nullable
+  @NullableDecl
   @Override
   public Object get(File file, String attribute) {
     if (attribute.equals("acl")) {

--- a/jimfs/src/main/java/com/google/common/jimfs/AttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AttributeProvider.java
@@ -24,7 +24,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.util.Arrays;
 import java.util.Map;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Abstract provider for handling a specific file attribute view.
@@ -87,7 +87,7 @@ public abstract class AttributeProvider {
    * Returns the value of the given attribute in the given file or null if the attribute is not
    * supported by this provider.
    */
-  @Nullable
+  @NullableDecl
   public abstract Object get(File file, String attribute);
 
   /**
@@ -108,7 +108,7 @@ public abstract class AttributeProvider {
    * Returns the type of file attributes object this provider supports, or null if it doesn't
    * support reading its attributes as an object.
    */
-  @Nullable
+  @NullableDecl
   public Class<? extends BasicFileAttributes> attributesType() {
     return null;
   }

--- a/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
@@ -36,7 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Service providing all attribute related operations for a file store. One piece of the file store
@@ -204,7 +204,7 @@ final class AttributeService {
     return value;
   }
 
-  @Nullable
+  @NullableDecl
   private Object getAttributeInternal(File file, String view, String attribute) {
     AttributeProvider provider = providersByName.get(view);
     if (provider == null) {
@@ -259,7 +259,7 @@ final class AttributeService {
    * if the view type is not supported.
    */
   @SuppressWarnings("unchecked")
-  @Nullable
+  @NullableDecl
   public <V extends FileAttributeView> V getFileAttributeView(FileLookup lookup, Class<V> type) {
     AttributeProvider provider = providersByViewType.get(type);
 

--- a/jimfs/src/main/java/com/google/common/jimfs/BasicAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/BasicAttributeProvider.java
@@ -23,7 +23,7 @@ import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Attribute provider that provides attributes common to all file systems, the {@link
@@ -148,9 +148,9 @@ final class BasicAttributeProvider extends AttributeProvider {
 
     @Override
     public void setTimes(
-        @Nullable FileTime lastModifiedTime,
-        @Nullable FileTime lastAccessTime,
-        @Nullable FileTime createTime)
+        @NullableDecl FileTime lastModifiedTime,
+        @NullableDecl FileTime lastAccessTime,
+        @NullableDecl FileTime createTime)
         throws IOException {
       File file = lookupFile();
 

--- a/jimfs/src/main/java/com/google/common/jimfs/Configuration.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Configuration.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Immutable configuration for an in-memory file system. A {@code Configuration} is passed to a
@@ -434,7 +434,7 @@ public final class Configuration {
     }
 
     private static void checkNormalizationNotSet(
-        PathNormalization n, @Nullable PathNormalization set) {
+        PathNormalization n, @NullableDecl PathNormalization set) {
       if (set != null) {
         throw new IllegalArgumentException(
             "can't set normalization " + n + ": normalization " + set + " already set");

--- a/jimfs/src/main/java/com/google/common/jimfs/Directory.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Directory.java
@@ -20,7 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Iterator;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A table of {@linkplain DirectoryEntry directory entries}.
@@ -103,7 +103,7 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
   }
 
   /** Returns the entry for the given name in this table or null if no such entry exists. */
-  @Nullable
+  @NullableDecl
   public DirectoryEntry get(Name name) {
     int index = bucketIndex(name, table.length);
 
@@ -334,7 +334,7 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
   public Iterator<DirectoryEntry> iterator() {
     return new AbstractIterator<DirectoryEntry>() {
       int index;
-      @Nullable DirectoryEntry entry;
+      @NullableDecl DirectoryEntry entry;
 
       @Override
       protected DirectoryEntry computeNext() {

--- a/jimfs/src/main/java/com/google/common/jimfs/DirectoryEntry.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/DirectoryEntry.java
@@ -26,7 +26,7 @@ import java.nio.file.NotDirectoryException;
 import java.nio.file.NotLinkException;
 import java.nio.file.Path;
 import java.util.Objects;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Entry in a directory, containing references to the directory itself, the file the entry links to
@@ -40,11 +40,11 @@ final class DirectoryEntry {
   private final Directory directory;
   private final Name name;
 
-  @Nullable private final File file;
+  @NullableDecl private final File file;
 
-  @Nullable DirectoryEntry next; // for use in Directory
+  @NullableDecl DirectoryEntry next; // for use in Directory
 
-  DirectoryEntry(Directory directory, Name name, @Nullable File file) {
+  DirectoryEntry(Directory directory, Name name, @NullableDecl File file) {
     this.directory = checkNotNull(directory);
     this.name = checkNotNull(name);
     this.file = file;
@@ -135,7 +135,7 @@ final class DirectoryEntry {
   }
 
   /** Returns the file this entry links to or {@code null} if the file does not exist */
-  @Nullable
+  @NullableDecl
   public File fileOrNull() {
     return file;
   }

--- a/jimfs/src/main/java/com/google/common/jimfs/DosAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/DosAttributeProvider.java
@@ -27,7 +27,7 @@ import java.nio.file.attribute.DosFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.util.Map;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Attribute provider that provides the {@link DosFileAttributeView} ("dos") and allows the reading
@@ -75,7 +75,7 @@ final class DosAttributeProvider extends AttributeProvider {
     return false;
   }
 
-  @Nullable
+  @NullableDecl
   @Override
   public Object get(File file, String attribute) {
     if (ATTRIBUTES.contains(attribute)) {

--- a/jimfs/src/main/java/com/google/common/jimfs/File.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/File.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Table;
 import java.io.IOException;
 import java.util.concurrent.locks.ReadWriteLock;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * A file object, containing both the file's metadata and content.
@@ -42,7 +42,7 @@ public abstract class File {
   private long lastAccessTime;
   private long lastModifiedTime;
 
-  @Nullable // null when only the basic view is used (default)
+  @NullableDecl // null when only the basic view is used (default)
   private Table<String, String, Object> attributes;
 
   File(int id) {
@@ -102,7 +102,7 @@ public abstract class File {
    * Returns the read-write lock for this file's content, or {@code null} if there is no content
    * lock.
    */
-  @Nullable
+  @NullableDecl
   ReadWriteLock contentLock() {
     return null;
   }
@@ -223,7 +223,7 @@ public abstract class File {
   }
 
   /** Gets the value of the given attribute in the given view. */
-  @Nullable
+  @NullableDecl
   public final synchronized Object getAttribute(String view, String attribute) {
     if (attributes == null) {
       return null;
@@ -264,7 +264,7 @@ public abstract class File {
     target.putAll(attributes);
   }
 
-  private synchronized void putAll(@Nullable Table<String, String, Object> attributes) {
+  private synchronized void putAll(@NullableDecl Table<String, String, Object> attributes) {
     if (attributes != null && this.attributes != attributes) {
       if (this.attributes == null) {
         this.attributes = HashBasedTable.create();

--- a/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
@@ -48,7 +48,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * View of a file system with a specific working directory. As all file system operations need to
@@ -305,7 +305,7 @@ final class FileSystemView {
    * Looks up the regular file at the given path, throwing an exception if the file isn't a regular
    * file. Returns null if the file did not exist.
    */
-  @Nullable
+  @NullableDecl
   private RegularFile lookUpRegularFile(JimfsPath path, Set<OpenOption> options)
       throws IOException {
     store.readLock().lock();
@@ -692,13 +692,13 @@ final class FileSystemView {
   }
 
   /** Returns a file attribute view using the given lookup callback. */
-  @Nullable
+  @NullableDecl
   public <V extends FileAttributeView> V getFileAttributeView(FileLookup lookup, Class<V> type) {
     return store.getFileAttributeView(lookup, type);
   }
 
   /** Returns a file attribute view for the given path in this view. */
-  @Nullable
+  @NullableDecl
   public <V extends FileAttributeView> V getFileAttributeView(
       final JimfsPath path, Class<V> type, final Set<? super LinkOption> options) {
     return store.getFileAttributeView(

--- a/jimfs/src/main/java/com/google/common/jimfs/FileTree.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileTree.java
@@ -27,7 +27,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * The tree of directories and files for the file system. Contains the file system root directories
@@ -63,7 +63,7 @@ final class FileTree {
    * Gets the directory entry for the root with the given name or {@code null} if no such root
    * exists.
    */
-  @Nullable
+  @NullableDecl
   public DirectoryEntry getRoot(Name name) {
     Directory dir = roots.get(name);
     return dir == null ? null : dir.entryInParent();
@@ -83,7 +83,7 @@ final class FileTree {
     return result;
   }
 
-  @Nullable
+  @NullableDecl
   private DirectoryEntry lookUp(
       File dir, JimfsPath path, Set<? super LinkOption> options, int linkDepth) throws IOException {
     ImmutableList<Name> names = path.names();
@@ -114,7 +114,7 @@ final class FileTree {
    * Looks up the given names against the given base file. If the file is not a directory, the
    * lookup fails.
    */
-  @Nullable
+  @NullableDecl
   private DirectoryEntry lookUp(
       File dir, Iterable<Name> names, Set<? super LinkOption> options, int linkDepth)
       throws IOException {
@@ -151,9 +151,9 @@ final class FileTree {
   }
 
   /** Looks up the last element of a path. */
-  @Nullable
+  @NullableDecl
   private DirectoryEntry lookUpLast(
-      @Nullable File dir, Name name, Set<? super LinkOption> options, int linkDepth)
+      @NullableDecl File dir, Name name, Set<? super LinkOption> options, int linkDepth)
       throws IOException {
     Directory directory = toDirectory(dir);
     if (directory == null) {
@@ -177,7 +177,7 @@ final class FileTree {
    * Returns the directory entry located by the target path of the given symbolic link, resolved
    * relative to the given directory.
    */
-  @Nullable
+  @NullableDecl
   private DirectoryEntry followSymbolicLink(File dir, SymbolicLink link, int linkDepth)
       throws IOException {
     if (linkDepth >= MAX_SYMBOLIC_LINK_DEPTH) {
@@ -196,7 +196,7 @@ final class FileTree {
    * we find an entry [bar -> "." -> bar], we instead return the entry for bar in its parent, [foo
    * -> "bar" -> bar].
    */
-  @Nullable
+  @NullableDecl
   private DirectoryEntry getRealEntry(DirectoryEntry entry) {
     Name name = entry.name();
 
@@ -209,8 +209,8 @@ final class FileTree {
     }
   }
 
-  @Nullable
-  private Directory toDirectory(@Nullable File file) {
+  @NullableDecl
+  private Directory toDirectory(@NullableDecl File file) {
     return file == null || !file.isDirectory() ? null : (Directory) file;
   }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/GuardedBy.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/GuardedBy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.jimfs;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+// TODO(cpovirk): Delete this in favor of the copy in Error Prone once that has a module name.
+/** Indicates that the annotated element should be used only while holding the specified lock. */
+@Target({FIELD, METHOD})
+@Retention(CLASS)
+@interface GuardedBy {
+  /**
+   * The lock that should be held, specified in the format <a
+   * href="http://jcip.net/annotations/doc/net/jcip/annotations/GuardedBy.html">given in Java
+   * Concurrency in Practice</a>.
+   */
+  String value();
+}

--- a/jimfs/src/main/java/com/google/common/jimfs/Jimfs.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Jimfs.java
@@ -33,7 +33,7 @@ import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Static factory methods for creating new Jimfs file systems. File systems may either be created
@@ -174,7 +174,7 @@ public final class Jimfs {
    * The system-loaded instance of {@code SystemJimfsFileSystemProvider}, or {@code null} if it
    * could not be found or loaded.
    */
-  @Nullable static final FileSystemProvider systemProvider = getSystemJimfsProvider();
+  @NullableDecl static final FileSystemProvider systemProvider = getSystemJimfsProvider();
 
   /**
    * Returns the system-loaded instance of {@code SystemJimfsFileSystemProvider} or {@code null} if
@@ -188,7 +188,7 @@ public final class Jimfs {
    * same class loader) as the class whose static cache a {@code JimfsFileSystem} instance will be
    * placed in when {@code FileSystems.newFileSystem} is called in {@code Jimfs.newFileSystem}.
    */
-  @Nullable
+  @NullableDecl
   private static FileSystemProvider getSystemJimfsProvider() {
     try {
       for (FileSystemProvider provider : FileSystemProvider.installedProviders()) {

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsAsynchronousFileChannel.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsAsynchronousFileChannel.java
@@ -32,7 +32,7 @@ import java.nio.channels.FileLock;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * {@link AsynchronousFileChannel} implementation that delegates to a {@link JimfsFileChannel}.
@@ -55,7 +55,9 @@ final class JimfsAsynchronousFileChannel extends AsynchronousFileChannel {
   }
 
   private <R, A> void addCallback(
-      ListenableFuture<R> future, CompletionHandler<R, ? super A> handler, @Nullable A attachment) {
+      ListenableFuture<R> future,
+      CompletionHandler<R, ? super A> handler,
+      @NullableDecl A attachment) {
     future.addListener(new CompletionHandlerCallback<>(future, handler, attachment), executor);
   }
 
@@ -75,7 +77,7 @@ final class JimfsAsynchronousFileChannel extends AsynchronousFileChannel {
       long position,
       long size,
       boolean shared,
-      @Nullable A attachment,
+      @NullableDecl A attachment,
       CompletionHandler<FileLock, ? super A> handler) {
     checkNotNull(handler);
     addCallback(lock(position, size, shared), handler, attachment);
@@ -120,7 +122,7 @@ final class JimfsAsynchronousFileChannel extends AsynchronousFileChannel {
   public <A> void read(
       ByteBuffer dst,
       long position,
-      @Nullable A attachment,
+      @NullableDecl A attachment,
       CompletionHandler<Integer, ? super A> handler) {
     addCallback(read(dst, position), handler, attachment);
   }
@@ -146,7 +148,7 @@ final class JimfsAsynchronousFileChannel extends AsynchronousFileChannel {
   public <A> void write(
       ByteBuffer src,
       long position,
-      @Nullable A attachment,
+      @NullableDecl A attachment,
       CompletionHandler<Integer, ? super A> handler) {
     addCallback(write(src, position), handler, attachment);
   }
@@ -189,12 +191,12 @@ final class JimfsAsynchronousFileChannel extends AsynchronousFileChannel {
 
     private final ListenableFuture<R> future;
     private final CompletionHandler<R, ? super A> completionHandler;
-    @Nullable private final A attachment;
+    @NullableDecl private final A attachment;
 
     private CompletionHandlerCallback(
         ListenableFuture<R> future,
         CompletionHandler<R, ? super A> completionHandler,
-        @Nullable A attachment) {
+        @NullableDecl A attachment) {
       this.future = checkNotNull(future);
       this.completionHandler = checkNotNull(completionHandler);
       this.attachment = attachment;

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileChannel.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.concurrent.GuardedBy;
 
 /**
  * A {@link FileChannel} implementation that reads and writes to a {@link RegularFile} object. The

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * {@link FileStore} implementation which provides methods for file creation, lookup and attribute
@@ -102,7 +102,7 @@ final class JimfsFileStore extends FileStore {
   }
 
   /** Returns the root directory with the given name or {@code null} if no such directory exists. */
-  @Nullable
+  @NullableDecl
   Directory getRoot(Name name) {
     DirectoryEntry entry = tree.getRoot(name);
     return entry == null ? null : (Directory) entry.file();
@@ -170,7 +170,7 @@ final class JimfsFileStore extends FileStore {
    * Returns an attribute view of the given type for the given file lookup callback, or {@code null}
    * if the view type is not supported.
    */
-  @Nullable
+  @NullableDecl
   <V extends FileAttributeView> V getFileAttributeView(FileLookup lookup, Class<V> type) {
     state.checkOpen();
     return attributes.getFileAttributeView(lookup, type);

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystem.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystem.java
@@ -33,7 +33,7 @@ import java.nio.file.WatchService;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * {@link FileSystem} implementation for Jimfs. Most behavior for the file system is implemented by
@@ -285,7 +285,7 @@ final class JimfsFileSystem extends FileSystem {
     return watchServiceConfig.newWatchService(defaultView, pathService);
   }
 
-  @Nullable private ExecutorService defaultThreadPool;
+  @NullableDecl private ExecutorService defaultThreadPool;
 
   /**
    * Returns a default thread pool to use for asynchronous file channels when users do not provide

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystemProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystemProvider.java
@@ -48,7 +48,7 @@ import java.nio.file.spi.FileSystemProvider;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * {@link FileSystemProvider} implementation for Jimfs. This provider implements the actual file
@@ -170,7 +170,7 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
   public AsynchronousFileChannel newAsynchronousFileChannel(
       Path path,
       Set<? extends OpenOption> options,
-      @Nullable ExecutorService executor,
+      @NullableDecl ExecutorService executor,
       FileAttribute<?>... attrs)
       throws IOException {
     // call newFileChannel and cast so that FileChannel support is checked there
@@ -320,7 +320,7 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
     getDefaultView(checkedPath).checkAccess(checkedPath);
   }
 
-  @Nullable
+  @NullableDecl
   @Override
   public <V extends FileAttributeView> V getFileAttributeView(
       Path path, Class<V> type, LinkOption... options) {

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsInputStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsInputStream.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 import java.io.IOException;
 import java.io.InputStream;
-import javax.annotation.concurrent.GuardedBy;
 
 /**
  * {@link InputStream} for reading from a file's {@link RegularFile}.

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsOutputStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsOutputStream.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkPositionIndexes;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.OutputStream;
-import javax.annotation.concurrent.GuardedBy;
 
 /**
  * {@link OutputStream} for writing to a {@link RegularFile}.

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsPath.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsPath.java
@@ -41,7 +41,7 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Jimfs implementation of {@link Path}. Creation of new {@code Path} objects is delegated to the
@@ -51,18 +51,18 @@ import javax.annotation.Nullable;
  */
 final class JimfsPath implements Path {
 
-  @Nullable private final Name root;
+  @NullableDecl private final Name root;
   private final ImmutableList<Name> names;
   private final PathService pathService;
 
-  public JimfsPath(PathService pathService, @Nullable Name root, Iterable<Name> names) {
+  public JimfsPath(PathService pathService, @NullableDecl Name root, Iterable<Name> names) {
     this.pathService = checkNotNull(pathService);
     this.root = root;
     this.names = ImmutableList.copyOf(names);
   }
 
   /** Returns the root name, or null if there is no root. */
-  @Nullable
+  @NullableDecl
   public Name root() {
     return root;
   }
@@ -76,7 +76,7 @@ final class JimfsPath implements Path {
    * Returns the file name of this path. Unlike {@link #getFileName()}, this may return the name of
    * the root if this is a root path.
    */
-  @Nullable
+  @NullableDecl
   public Name name() {
     if (!names.isEmpty()) {
       return Iterables.getLast(names);
@@ -421,7 +421,7 @@ final class JimfsPath implements Path {
   }
 
   @Override
-  public boolean equals(@Nullable Object obj) {
+  public boolean equals(@NullableDecl Object obj) {
     return obj instanceof JimfsPath && compareTo((JimfsPath) obj) == 0;
   }
 
@@ -435,7 +435,7 @@ final class JimfsPath implements Path {
     return pathService.toString(this);
   }
 
-  @Nullable
+  @NullableDecl
   private JimfsPath checkPath(Path other) {
     if (checkNotNull(other) instanceof JimfsPath && other.getFileSystem().equals(getFileSystem())) {
       return (JimfsPath) other;

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsSecureDirectoryStream.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsSecureDirectoryStream.java
@@ -35,7 +35,7 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileAttributeView;
 import java.util.Iterator;
 import java.util.Set;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Secure directory stream implementation that uses a {@link FileSystemView} with the stream's
@@ -87,7 +87,7 @@ final class JimfsSecureDirectoryStream implements SecureDirectoryStream<Path> {
 
   private final class DirectoryIterator extends AbstractIterator<Path> {
 
-    @Nullable private Iterator<Name> fileNames;
+    @NullableDecl private Iterator<Name> fileNames;
 
     @Override
     protected synchronized Path computeNext() {

--- a/jimfs/src/main/java/com/google/common/jimfs/Name.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Name.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.Ordering;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Immutable representation of a file name. Used both for the name components of paths and as the
@@ -77,7 +77,7 @@ final class Name {
   }
 
   @Override
-  public boolean equals(@Nullable Object obj) {
+  public boolean equals(@NullableDecl Object obj) {
     if (obj instanceof Name) {
       Name other = (Name) obj;
       return canonical.equals(other.canonical);

--- a/jimfs/src/main/java/com/google/common/jimfs/OwnerAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/OwnerAttributeProvider.java
@@ -26,7 +26,7 @@ import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Map;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Attribute provider that provides the {@link FileOwnerAttributeView} ("owner").
@@ -65,7 +65,7 @@ final class OwnerAttributeProvider extends AttributeProvider {
     return ImmutableMap.of("owner:owner", owner);
   }
 
-  @Nullable
+  @NullableDecl
   @Override
   public Object get(File file, String attribute) {
     if (attribute.equals("owner")) {

--- a/jimfs/src/main/java/com/google/common/jimfs/PathService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathService.java
@@ -38,7 +38,7 @@ import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Service for creating {@link JimfsPath} instances and handling other path-related operations.
@@ -162,7 +162,7 @@ final class PathService implements Comparator<JimfsPath> {
   }
 
   /** Returns a path with the given root (or no root, if null) and the given names. */
-  public JimfsPath createPath(@Nullable Name root, Iterable<Name> names) {
+  public JimfsPath createPath(@NullableDecl Name root, Iterable<Name> names) {
     ImmutableList<Name> nameList = ImmutableList.copyOf(Iterables.filter(names, NOT_EMPTY));
     if (root == null && nameList.isEmpty()) {
       // ensure the canonical empty path (one empty string name) is used rather than a path with
@@ -173,7 +173,7 @@ final class PathService implements Comparator<JimfsPath> {
   }
 
   /** Returns a path with the given root (or no root, if null) and the given names. */
-  protected final JimfsPath createPathInternal(@Nullable Name root, Iterable<Name> names) {
+  protected final JimfsPath createPathInternal(@NullableDecl Name root, Iterable<Name> names) {
     return new JimfsPath(this, root, names);
   }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/PathType.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathType.java
@@ -26,7 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.InvalidPathException;
 import java.util.Arrays;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * An object defining a specific type of path. Knows how to parse strings to a path and how to
@@ -164,7 +164,7 @@ public abstract class PathType {
   }
 
   /** Returns the string form of the given path. */
-  public abstract String toString(@Nullable String root, Iterable<String> names);
+  public abstract String toString(@NullableDecl String root, Iterable<String> names);
 
   /**
    * Returns the string form of the given path for use in the path part of a URI. The root element
@@ -211,10 +211,10 @@ public abstract class PathType {
   /** Simple result of parsing a path. */
   public static final class ParseResult {
 
-    @Nullable private final String root;
+    @NullableDecl private final String root;
     private final Iterable<String> names;
 
-    public ParseResult(@Nullable String root, Iterable<String> names) {
+    public ParseResult(@NullableDecl String root, Iterable<String> names) {
       this.root = root;
       this.names = checkNotNull(names);
     }
@@ -230,7 +230,7 @@ public abstract class PathType {
     }
 
     /** Returns the parsed root element, or null if there was no root. */
-    @Nullable
+    @NullableDecl
     public String root() {
       return root;
     }

--- a/jimfs/src/main/java/com/google/common/jimfs/PosixAttributeProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PosixAttributeProvider.java
@@ -35,7 +35,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Attribute provider that provides the {@link PosixFileAttributeView} ("posix") and allows reading
@@ -114,7 +114,7 @@ final class PosixAttributeProvider extends AttributeProvider {
         "posix:permissions", permissions);
   }
 
-  @Nullable
+  @NullableDecl
   @Override
   public Object get(File file, String attribute) {
     switch (attribute) {

--- a/jimfs/src/main/java/com/google/common/jimfs/StandardAttributeProviders.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/StandardAttributeProviders.java
@@ -17,7 +17,7 @@
 package com.google.common.jimfs;
 
 import com.google.common.collect.ImmutableMap;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Static registry of {@link AttributeProvider} implementations for the standard set of file
@@ -43,7 +43,7 @@ final class StandardAttributeProviders {
    * Returns the attribute provider for the given view, or {@code null} if the given view is not one
    * of the attribute views this supports.
    */
-  @Nullable
+  @NullableDecl
   public static AttributeProvider get(String view) {
     AttributeProvider provider = PROVIDERS.get(view);
 

--- a/jimfs/src/main/java/com/google/common/jimfs/UnixPathType.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/UnixPathType.java
@@ -19,7 +19,7 @@ package com.google.common.jimfs;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.nio.file.InvalidPathException;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Unix-style path type.
@@ -55,7 +55,7 @@ final class UnixPathType extends PathType {
   }
 
   @Override
-  public String toString(@Nullable String root, Iterable<String> names) {
+  public String toString(@NullableDecl String root, Iterable<String> names) {
     StringBuilder builder = new StringBuilder();
     if (root != null) {
       builder.append(root);

--- a/jimfs/src/main/java/com/google/common/jimfs/WindowsPathType.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/WindowsPathType.java
@@ -20,7 +20,7 @@ import java.nio.file.InvalidPathException;
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Windows-style path type.
@@ -134,7 +134,7 @@ final class WindowsPathType extends PathType {
   private static final Pattern DRIVE_LETTER_ROOT = Pattern.compile("^[a-zA-Z]:\\\\");
 
   /** Parses a normal drive-letter root, e.g. "C:\". */
-  @Nullable
+  @NullableDecl
   private String parseDriveRoot(String path) {
     Matcher drivePathMatcher = DRIVE_LETTER_ROOT.matcher(path);
     if (drivePathMatcher.find()) {
@@ -160,7 +160,7 @@ final class WindowsPathType extends PathType {
   }
 
   @Override
-  public String toString(@Nullable String root, Iterable<String> names) {
+  public String toString(@NullableDecl String root, Iterable<String> names) {
     StringBuilder builder = new StringBuilder();
     if (root != null) {
       builder.append(root);

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractPathMatcherTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractPathMatcherTest.java
@@ -33,7 +33,7 @@ import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.Iterator;
 import java.util.regex.PatternSyntaxException;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Abstract base class for tests of {@link PathMatcher} implementations.
@@ -48,7 +48,7 @@ public abstract class AbstractPathMatcherTest {
   protected abstract PathMatcher matcher(String pattern);
 
   /** Override to return a real matcher for the given pattern. */
-  @Nullable
+  @NullableDecl
   protected PathMatcher realMatcher(String pattern) {
     return null;
   }
@@ -77,7 +77,7 @@ public abstract class AbstractPathMatcherTest {
 
     private final PathMatcher matcher;
 
-    @Nullable private final PathMatcher realMatcher;
+    @NullableDecl private final PathMatcher realMatcher;
 
     PatternAsserter(String pattern) {
       this.matcher = matcher(pattern);

--- a/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import java.util.HashSet;
 import java.util.Set;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -365,7 +365,7 @@ public class DirectoryTest {
     return new DirectoryEntry(A, Name.simple(name), A);
   }
 
-  private static DirectoryEntry entry(Directory dir, String name, @Nullable File file) {
+  private static DirectoryEntry entry(Directory dir, String name, @NullableDecl File file) {
     return new DirectoryEntry(dir, Name.simple(name), file);
   }
 

--- a/jimfs/src/test/java/com/google/common/jimfs/FileTreeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/FileTreeTest.java
@@ -31,7 +31,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -87,7 +87,7 @@ public class FileTreeTest {
             }
 
             @Override
-            public String toString(@Nullable String root, Iterable<String> names) {
+            public String toString(@NullableDecl String root, Iterable<String> names) {
               root = Strings.nullToEmpty(root);
               return root + Joiner.on('/').join(names);
             }

--- a/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathSubject.java
@@ -36,7 +36,7 @@ import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Subject for doing assertions on file system paths.
@@ -103,7 +103,7 @@ public final class PathSubject extends Subject {
   }
 
   /** Asserts that the path has the given root component. */
-  public PathSubject hasRootComponent(@Nullable String root) {
+  public PathSubject hasRootComponent(@NullableDecl String root) {
     Path rootComponent = actual.getRoot();
     if (root == null && rootComponent != null) {
       failWithActual("expected to have root component", root);

--- a/jimfs/src/test/java/com/google/common/jimfs/PathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathTypeTest.java
@@ -22,7 +22,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.net.URI;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -94,7 +94,7 @@ public class PathTypeTest {
     assertUriRoundTripsCorrectly(type, "$foo/bar baz");
   }
 
-  static void assertParseResult(ParseResult result, @Nullable String root, String... names) {
+  static void assertParseResult(ParseResult result, @NullableDecl String root, String... names) {
     assertThat(result.root()).isEqualTo(root);
     assertThat(result.names()).containsExactly((Object[]) names).inOrder();
   }
@@ -126,7 +126,7 @@ public class PathTypeTest {
     }
 
     @Override
-    public String toString(@Nullable String root, Iterable<String> names) {
+    public String toString(@NullableDecl String root, Iterable<String> names) {
       StringBuilder builder = new StringBuilder();
       if (root != null) {
         builder.append(root);

--- a/jimfs/src/test/java/com/google/common/jimfs/TestAttributeProvider.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/TestAttributeProvider.java
@@ -26,7 +26,7 @@ import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** @author Colin Decker */
 public final class TestAttributeProvider extends AttributeProvider {
@@ -133,9 +133,9 @@ public final class TestAttributeProvider extends AttributeProvider {
 
     @Override
     public void setTimes(
-        @Nullable FileTime lastModifiedTime,
-        @Nullable FileTime lastAccessTime,
-        @Nullable FileTime createTime)
+        @NullableDecl FileTime lastModifiedTime,
+        @NullableDecl FileTime lastAccessTime,
+        @NullableDecl FileTime createTime)
         throws IOException {
       basicView.setTimes(lastModifiedTime, lastAccessTime, createTime);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
       <dependency>
         <groupId>com.ibm.icu</groupId>
         <artifactId>icu4j</artifactId>
-        <version>61.1</version>
+        <version>65.1</version>
       </dependency>
 
       <!-- Compile-time dependencies -->
@@ -150,7 +150,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
@@ -163,6 +163,10 @@
         <plugin>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>1.6</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <auto-service.version>1.0-rc6</auto-service.version>
     <java.version>1.7</java.version>
     <guava.version>27.0.1-android</guava.version>
   </properties>
@@ -109,8 +110,8 @@
       <!-- Compile-time dependencies -->
       <dependency>
         <groupId>com.google.auto.service</groupId>
-        <artifactId>auto-service</artifactId>
-        <version>1.0-rc3</version>
+        <artifactId>auto-service-annotations</artifactId>
+        <version>${auto-service.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
@@ -189,6 +190,11 @@
               <groupId>com.google.guava</groupId>
               <artifactId>guava-beta-checker</artifactId>
               <version>1.0</version>
+            </path>
+            <path>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>${auto-service.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-compat-qual</artifactId>
+        <version>2.5.5</version>
+      </dependency>
 
       <!-- Test dependencies -->
       <dependency>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update Travis JDK to JDK11.

This is an attempt to fix the error:

install-jdk.sh 2019-09-17
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .

It is similar to CL 253584474

20ba8fcad080c61c8485fc34455e71eca1b8cabc

-------

<p> Mostly migrate off jsr305.

- Mostly migrate to Checker Framework declaration annotations.
- Migrate @GuardedBy to a custom annotation for now. (We would migrate to Error Prone's, but that's causing me problems as I experiment with JPMS.)

Compare to b/69411537 for Guava.

I've left @ParametersAreNonnullByDefault in place for now, but we'd need to remove it to fully eliminate the jsr305 dep.

RELNOTES=Migrated from jsr305 `@Nullable` to Checker Framework `@NullableDecl`. In addition to the new dependency on the Checker Framework annotations, we keep the dependency on jsr305 for now so that we can keep using `@ParametersAreNonNullByDefault`.

ebbb8630f6949b5764d76c228f30d665f9eaaf1f

-------

<p> Update versions of some plugins and a dependency to prepare for Java 11.

- We may want an ICU4J new enough to contain an Automatic-Module-Name.
- Our old maven-surefire-plugin breaks with NullPointerException with JDK10+: https://bugzilla.redhat.com/show_bug.cgi?id=1572708
- Our old maven-compiler-plugin breaks with JDK11: https://github.com/google/error-prone/issues/1136#issuecomment-427816741 (I don't have the error message handy anymore.)

8556f115c029d0269ef4c5988304db43e6b9f3fc

-------

<p> Use AutoService as a proper annotation processor.

I was going to say that this also paves the way for including the annotation as a non-optional dependency, should we wish to follow our Guava precedent for annotations:
- https://github.com/google/guava/issues/2824
- https://github.com/google/guava/issues/2721

But I see that it's retention=SOURCE anyway, so there isn't much reason to do that -- except maybe consistency with other annotation packages someday. (Maybe it's still a negative then, as it might still let people rely on our transitive dependency?)

I think the relationship of all this to Java 11 was that I might have to set an Automatic-Module-Name on AutoService, and it makes more sense to set it after we've done the processor-vs.-annotation artifact split. Once I was upgrading, it made sense to set up the annotation processor the Right Away, now that we're using a version in which that works. (Or maybe it always worked but now it's nice that it gets the processor off the classpath?) Or maybe there was some other reason for the change to the annotation-processor setup; once again, I forget. It looks like it might have been that AutoService stops running when I switch how we run Error Prone. Hopefully this was the solution :) But it's probably a good idea in any case.

This CL is basically following the "alternatively" instructions in https://github.com/google/auto/blob/master/value/userguide/index.md#in-pomxml

...even though the AutoService instructions haven't been similarly updated yet: https://github.com/google/auto/tree/master/service#download

9ac60c72ceaaf79080c15d66508d691c150ae7ef