### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 language: java
 
 jdk:
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 install: mvn install -U -DskipTests=true
 

--- a/jimfs/pom.xml
+++ b/jimfs/pom.xml
@@ -99,15 +99,7 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <encoding>UTF-8</encoding>
-          <docencoding>UTF-8</docencoding>
-          <charset>UTF-8</charset>
           <excludePackageNames>com.google.jimfs.internal</excludePackageNames>
-          <links>
-            <link>http://google.github.io/guava/releases/${guava.version}/api/docs/</link>
-            <link>http://icu-project.org/apiref/icu4j/</link>
-            <link>https://docs.oracle.com/javase/9/docs/api/</link>
-          </links>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.8.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,21 @@
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.1</version>
+          <configuration>
+            <debug>true</debug>
+            <encoding>UTF-8</encoding>
+            <docencoding>UTF-8</docencoding>
+            <charset>UTF-8</charset>
+            <detectJavaApiLink>false</detectJavaApiLink>
+            <links>
+              <link>https://checkerframework.org/api/</link>
+              <link>https://guava.dev/releases/${guava.version}/api/docs/</link>
+              <link>https://unicode-org.github.io/icu-docs/apidoc/released/icu4j</link>
+              <!-- When building against Java 8, the Java 11 link below is overridden to point to an older version (Java 9, the newest one that works). -->
+              <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
+            </links>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-gpg-plugin</artifactId>
@@ -242,7 +256,6 @@
       <reporting>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <additionalOptions>
@@ -255,7 +268,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <additionalOptions>
@@ -274,8 +286,25 @@
       <activation>
         <jdk>1.8</jdk>
       </activation>
+      <reporting>
+        <plugins>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <links>
+                <link>https://checkerframework.org/api/</link>
+                <link>https://guava.dev/releases/${guava.version}/api/docs/</link>
+                <link>https://unicode-org.github.io/icu-docs/apidoc/released/icu4j</link>
+                <link>https://docs.oracle.com/javase/9/docs/api/</link>
+              </links>
+            </configuration>
+          </plugin>
+        </plugins>
+      </reporting>
       <build>
         <plugins>
+          <!-- https://errorprone.info/docs/installation#maven -->
+          <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
@@ -284,6 +313,18 @@
               <compilerArgs combine.children="append">
                 <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
               </compilerArgs>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <links>
+                <link>https://checkerframework.org/api/</link>
+                <link>https://guava.dev/releases/${guava.version}/api/docs/</link>
+                <link>https://unicode-org.github.io/icu-docs/apidoc/released/icu4j</link>
+                <link>https://docs.oracle.com/javase/9/docs/api/</link>
+              </links>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,14 @@
     <auto-service.version>1.0-rc6</auto-service.version>
     <java.version>1.7</java.version>
     <guava.version>27.0.1-android</guava.version>
+    <!--
+      NOTE: When updating errorprone.version, also update javac.version to the
+      version used by the new error-prone version. You should be able to find
+      it in the properties section of
+      https://github.com/google/error-prone/blob/v${errorprone.version}/pom.xml
+      -->
+    <errorprone.version>2.3.3</errorprone.version>
+    <javac.version>9+181-r4173-1</javac.version>
   </properties>
 
   <dependencyManagement>
@@ -183,9 +191,16 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
-          <compilerId>javac-with-errorprone</compilerId>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
           <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${errorprone.version}</version>
+            </path>
             <path>
               <groupId>com.google.guava</groupId>
               <artifactId>guava-beta-checker</artifactId>
@@ -207,34 +222,23 @@
             </goals>
             <configuration>
               <compilerArgs>
-                <arg>-Xep:BetaApi:OFF</arg> <!-- Disable Beta Checker for tests -->
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne -Xep:BetaApi:OFF</arg> <!-- Disable Beta Checker for tests -->
               </compilerArgs>
             </configuration>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.2.0</version>
-          </dependency>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.3</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>
 
   <profiles>
     <profile>
-      <id>jdk8</id>
+      <id>jdk8plus</id>
       <activation>
         <jdk>[1.8,)</jdk>
       </activation>
-      <!-- Disable HTML checking in doclint under JDK 8 -->
+      <!-- Disable HTML checking in doclint under JDK 8 and higher -->
       <reporting>
         <plugins>
           <plugin>
@@ -257,6 +261,29 @@
               <additionalOptions>
                 <additionalOption>-Xdoclint:none</additionalOption>
               </additionalOptions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- https://errorprone.info/docs/installation#maven -->
+    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
+    <profile>
+      <id>jdk8exactly</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+              </compilerArgs>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Travis: use 'openjdk8' instead of 'oraclejdk8'

(This now restores coverage for 8, and I made a similar change for 11.)

Fixes #89

d30e34468267615316067d7c21dca8f3e2af23db

-------

<p> maven-compiler-plugin 3.8.1

Fixes #90

54912ecbf0cbe136de7d86b63685cab8b6618e7c

-------

<p> Run Error Prone as a plugin.

If run in the old style, it uses javac9, which can't handle the Java 11 class files in the JDK11 bootclasspath.

This follows the instructions at https://errorprone.info/docs/installation#maven

Note also the need to include -Xep:BetaApi:OFF in the same arg as -Xplugin:ErrorProne: https://github.com/google/error-prone/issues/1136#issuecomment-427816741 https://github.com/google/error-prone/pull/1115

(Also, incidentally update Error Prone itself. I forget whether I had a Java-11-related reason for that, but it seems like a good idea.)

7e467aad2d8fedbf15b7842702fd2f5aeda783a4

-------

<p> Prepare Javadoc for Java 11, and make other improvements:

- Move nearly all Javadoc configuration to the parent POM.
- Update Guava and ICU4J link locations. The current links resolve to the Javadoc -- but only after a redirect, which Javadoc doesn't like: https://bugs.openjdk.java.net/browse/JDK-8190312
- Update maven-javadoc-plugin to 3.1.1. (This version knows how to work around the aforementioned redirect problem, should it happen again.)
- Add links to Checker Framework. For some reason, this isn't working under Java 11. I haven't investigated.
- Disable detectJavaApiLink, and fill in https://docs.oracle.com/javase/9/docs/api/ for Java 8 and https://docs.oracle.com/en/java/javase/11/docs/api/ for newer versions. (I've tested only with Java 8 and 11, so hopefully the "newer versions" behavior is OK for 9 and 10.)
  It does look like it may be necessary to duplicate all the links in 3 places :\
  This is all in service of preventing:
    [ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/9/docs/api/ are in the unnamed module.
  Traditionally we solve this problem by setting <source>8</source> on Javadoc (CL 235241314, CL 236159968). That would probably work here, but I've been experimenting with <source>9</source> (for proper modules support in jimfs), so that might not be an option soon. Or maybe it still would be, but I'd have to exclude module-info.java, but then I wonder if that will trigger modules problems? In any case, it seems more future-proof to solve this the right(?) way.

7b2eccd04653839a7fa002f762005f9c0433f0b9