### PR TITLE
Moe Sync

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/PathService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathService.java
@@ -199,6 +199,9 @@ final class PathService implements Comparator<JimfsPath> {
 
   /** Creates a hash code for the given path. */
   public int hash(JimfsPath path) {
+    // Note: JimfsPath.equals() is implemented using the compare() method below;
+    // equalityUsesCanonicalForm is taken into account there via the namesOrdering, which is set
+    // at construction time.
     int hash = 31;
     hash = 31 * hash + getFileSystem().hashCode();
 
@@ -251,7 +254,9 @@ final class PathService implements Comparator<JimfsPath> {
    */
   public PathMatcher createPathMatcher(String syntaxAndPattern) {
     return PathMatchers.getPathMatcher(
-        syntaxAndPattern, type.getSeparator() + type.getOtherSeparators(), displayNormalizations);
+        syntaxAndPattern,
+        type.getSeparator() + type.getOtherSeparators(),
+        equalityUsesCanonicalForm ? canonicalNormalizations : displayNormalizations);
   }
 
   private static final Predicate<Object> NOT_EMPTY =

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsWindowsLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsWindowsLikeFileSystemTest.java
@@ -306,7 +306,9 @@ public class JimfsWindowsLikeFileSystemTest extends AbstractJimfsIntegrationTest
     assertThatPath("C:\\foo\\bar\\baz\\stuff").matches("glob:C:\\\\foo\\\\**");
     assertThatPath("C:\\foo\\bar\\baz\\stuff").matches("glob:C:\\\\**\\\\stuff");
     assertThatPath("C:\\foo").matches("glob:C:\\\\[a-z]*");
-    assertThatPath("C:\\Foo").doesNotMatch("glob:C:\\\\[a-z]*");
+    assertThatPath("C:\\Foo").matches("glob:C:\\\\[a-z]*");
+    assertThatPath("C:\\foo").matches("glob:C:\\\\[A-Z]*");
+    assertThatPath("C:\\Foo").matches("glob:C:\\\\[A-Z]*");
     assertThatPath("C:\\foo\\bar\\baz\\Stuff.java").matches("glob:**\\\\*.java");
     assertThatPath("C:\\foo\\bar\\baz\\Stuff.java").matches("glob:**\\\\*.{java,class}");
     assertThatPath("C:\\foo\\bar\\baz\\Stuff.class").matches("glob:**\\\\*.{java,class}");
@@ -331,7 +333,9 @@ public class JimfsWindowsLikeFileSystemTest extends AbstractJimfsIntegrationTest
     assertThatPath("C:\\foo\\bar\\baz\\stuff").matches("glob:C:/foo/**");
     assertThatPath("C:\\foo\\bar\\baz\\stuff").matches("glob:C:/**/stuff");
     assertThatPath("C:\\foo").matches("glob:C:/[a-z]*");
-    assertThatPath("C:\\Foo").doesNotMatch("glob:C:/[a-z]*");
+    assertThatPath("C:\\Foo").matches("glob:C:/[a-z]*");
+    assertThatPath("C:\\foo").matches("glob:C:/[A-Z]*");
+    assertThatPath("C:\\Foo").matches("glob:C:/[A-Z]*");
     assertThatPath("C:\\foo\\bar\\baz\\Stuff.java").matches("glob:**/*.java");
     assertThatPath("C:\\foo\\bar\\baz\\Stuff.java").matches("glob:**/*.{java,class}");
     assertThatPath("C:\\foo\\bar\\baz\\Stuff.class").matches("glob:**/*.{java,class}");

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <auto-service.version>1.0-rc6</auto-service.version>
     <java.version>1.7</java.version>
     <guava.version>27.0.1-android</guava.version>
+    <surefire.version>3.0.0-M3</surefire.version>
     <!--
       NOTE: When updating errorprone.version, also update javac.version to the
       version used by the new error-prone version. You should be able to find
@@ -189,7 +190,15 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>${surefire.version}</version>
+          <!-- For some reason, we need this for our internal tests that run in offline mode: -->
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit4</artifactId>
+              <version>${surefire.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change Jimfs PathMatchers to use the regex flags indicated by the Configuration's canonical (rather than display) path normalization when the Configuration is set to use canonical normalization for path equality.

This basically affects Windows-like configurations, as Windows/NTFS is the only file system (at least of those Jimfs has a built-in equivalent for) that uses these settings. Essentially, Windows does not normalize the case of file names when displaying paths but it does normalize them (case fold) for comparison and equality. On a real Windows file system, a PathMatcher for "glob:**.txt" or "glob:**.TXT" would match both files ending in ".txt" and files ending in ".TXT".

Fixes https://github.com/google/jimfs/issues/91

RELNOTES=Fixed behavior of `PathMatcher`s for Windows-like configurations to do case-insensitive matching.

4e5e166a5248647cfcc7a2bfb3223cc7faa35fb5

-------

<p> Run Maven tests for jimfs in our internal builds.

Hopefully this will catch future breakages.

65c454775e22b75122c83109b4b37e9d417c6ce8