### PR TITLE
Moe Sync

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/Directory.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Directory.java
@@ -200,14 +200,6 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
   }
 
   /**
-   * Adds the given entry to the directory, overwriting an existing entry with the same name if such
-   * an entry exists.
-   */
-  private void forcePut(DirectoryEntry entry) {
-    put(entry, true);
-  }
-
-  /**
    * Adds the given entry to the directory. {@code overwriteExisting} determines whether an existing
    * entry with the same name should be overwritten or an exception should be thrown.
    */
@@ -256,6 +248,14 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
     }
 
     entry.file().incrementLinkCount();
+  }
+
+  /**
+   * Adds the given entry to the directory, overwriting an existing entry with the same name if such
+   * an entry exists.
+   */
+  private void forcePut(DirectoryEntry entry) {
+    put(entry, true);
   }
 
   private boolean expandIfNeeded() {

--- a/jimfs/src/main/java/com/google/common/jimfs/FileTree.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileTree.java
@@ -216,6 +216,6 @@ final class FileTree {
 
   private static boolean isEmpty(ImmutableList<Name> names) {
     // the empty path (created by FileSystem.getPath("")), has no root and a single name, ""
-    return names.isEmpty() || names.size() == 1 && names.get(0).toString().isEmpty();
+    return names.isEmpty() || (names.size() == 1 && names.get(0).toString().isEmpty());
   }
 }

--- a/jimfs/src/main/java/com/google/common/jimfs/HeapDisk.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/HeapDisk.java
@@ -61,11 +61,6 @@ final class HeapDisk {
     this.blockCache = createBlockCache(maxCachedBlockCount);
   }
 
-  /** Returns the nearest multiple of {@code blockSize} that is <= {@code size}. */
-  private static int toBlockCount(long size, int blockSize) {
-    return (int) LongMath.divide(size, blockSize, RoundingMode.FLOOR);
-  }
-
   /**
    * Creates a new disk with the given {@code blockSize}, {@code maxBlockCount} and {@code
    * maxCachedBlockCount}.
@@ -79,6 +74,11 @@ final class HeapDisk {
     this.maxBlockCount = maxBlockCount;
     this.maxCachedBlockCount = maxCachedBlockCount;
     this.blockCache = createBlockCache(maxCachedBlockCount);
+  }
+
+  /** Returns the nearest multiple of {@code blockSize} that is <= {@code size}. */
+  private static int toBlockCount(long size, int blockSize) {
+    return (int) LongMath.divide(size, blockSize, RoundingMode.FLOOR);
   }
 
   private RegularFile createBlockCache(int maxCachedBlockCount) {

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystemProvider.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileSystemProvider.java
@@ -89,13 +89,6 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
   }
 
   @Override
-  public FileSystem getFileSystem(URI uri) {
-    throw new UnsupportedOperationException(
-        "This method should not be called directly; "
-            + "use FileSystems.getFileSystem(URI) instead.");
-  }
-
-  @Override
   public FileSystem newFileSystem(Path path, Map<String, ?> env) throws IOException {
     JimfsPath checkedPath = checkPath(path);
     checkNotNull(env);
@@ -114,6 +107,18 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
   }
 
   @Override
+  public FileSystem getFileSystem(URI uri) {
+    throw new UnsupportedOperationException(
+        "This method should not be called directly; "
+            + "use FileSystems.getFileSystem(URI) instead.");
+  }
+
+  /** Gets the file system for the given path. */
+  private static JimfsFileSystem getFileSystem(Path path) {
+    return (JimfsFileSystem) checkPath(path).getFileSystem();
+  }
+
+  @Override
   public Path getPath(URI uri) {
     throw new UnsupportedOperationException(
         "This method should not be called directly; " + "use Paths.get(URI) instead.");
@@ -125,11 +130,6 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
     }
     throw new ProviderMismatchException(
         "path " + path + " is not associated with a Jimfs file system");
-  }
-
-  /** Gets the file system for the given path. */
-  private static JimfsFileSystem getFileSystem(Path path) {
-    return (JimfsFileSystem) checkPath(path).getFileSystem();
   }
 
   /** Returns the default file system view for the given path. */
@@ -258,11 +258,6 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
     copy(source, target, Options.getCopyOptions(options), false);
   }
 
-  @Override
-  public void move(Path source, Path target, CopyOption... options) throws IOException {
-    copy(source, target, Options.getMoveOptions(options), true);
-  }
-
   private void copy(Path source, Path target, ImmutableSet<CopyOption> options, boolean move)
       throws IOException {
     JimfsPath sourcePath = checkPath(source);
@@ -271,6 +266,11 @@ final class JimfsFileSystemProvider extends FileSystemProvider {
     FileSystemView sourceView = getDefaultView(sourcePath);
     FileSystemView targetView = getDefaultView(targetPath);
     sourceView.copy(sourcePath, targetView, targetPath, options, move);
+  }
+
+  @Override
+  public void move(Path source, Path target, CopyOption... options) throws IOException {
+    copy(source, target, Options.getMoveOptions(options), true);
   }
 
   @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix 6 ErrorProneStyle findings:
* Constructors and methods with the same name should appear sequentially with no other code in between. Please re-order or re-name methods.
* Use grouping parenthesis to make the operator precedence explicit

823c522f0c5f4b67fbc2a12395b94cbac6130810