### PR TITLE
MOE Sync 2020-04-28

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsPath.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsPath.java
@@ -251,11 +251,7 @@ final class JimfsPath implements Path {
 
   /** Resolves the given name against this path. The name is assumed not to be a root name. */
   JimfsPath resolve(Name name) {
-    if (name.toString().isEmpty()) {
-      return this;
-    }
-    return pathService.createPathInternal(
-        root, ImmutableList.<Name>builder().addAll(names).add(name).build());
+    return resolve(pathService.createFileName(name));
   }
 
   @Override

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsPathTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsPathTest.java
@@ -219,6 +219,17 @@ public class JimfsPathTest {
   }
 
   @Test
+  public void testResolveName_againstEmptyPath() {
+    // resolve(Name) is only used in the DirectoryStream implementation, so it's only used to
+    // resolve the names of real existing files against some base directory's path. The base
+    // directory path could be the working directory path (i.e. just an empty string), in which case
+    // we need to be sure to return a path that is just the name of the file as opposed a path with
+    // two names, one being the empty string and the other the file name).
+    // See https://github.com/google/jimfs/issues/105
+    assertPathEquals("foo", pathService.emptyPath().resolve(Name.simple("foo")));
+  }
+
+  @Test
   public void testResolveSibling_givenEmptyPath() {
     Path path = pathService.parsePath("foo/bar");
     Path resolved = path.resolveSibling("");


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix JimfsPath.resolve(Name) to work correctly when the path is the empty path. Unlike JimfsPath.resolve(String) or resolve(Path), it was incorrectly including its (empty string) name in the resolved path. This only showed up when iterating the files in the working directory via its DirectoryStream; the Paths you would get would look like "/foo.txt" instead of just "foo.txt".

Fixes https://github.com/google/jimfs/issues/105

RELNOTES=Fixed an issue where incorrect `Path`s were returned from a `DirectoryStream` for the working directory (i.e. the directory `fs.getPath("")` returns). See #105.

4e11c65449fc360abfd1d5b93b46299873bb9139