### PR TITLE
Refactored four test method pairs

### DIFF
--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsInputStreamTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsInputStreamTest.java
@@ -75,21 +75,13 @@ public class JimfsInputStreamTest {
   }
 
   @Test
-  public void testRead_partialArray() throws IOException {
-    JimfsInputStream in = newInputStream(1, 2, 3, 4, 5, 6, 7, 8);
-    byte[] bytes = new byte[12];
-    assertThat(in.read(bytes, 0, 8)).isEqualTo(8);
-    assertArrayEquals(bytes(1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0), bytes);
-    assertEmpty(in);
+  public void testRead_partialArray() throws Exception {
+    this.jimfsInputStreamTestTestRead_partialTemplate(8);
   }
 
   @Test
-  public void testRead_partialArray_sliceLarger() throws IOException {
-    JimfsInputStream in = newInputStream(1, 2, 3, 4, 5, 6, 7, 8);
-    byte[] bytes = new byte[12];
-    assertThat(in.read(bytes, 0, 10)).isEqualTo(8);
-    assertArrayEquals(bytes(1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0), bytes);
-    assertEmpty(in);
+  public void testRead_partialArray_sliceLarger() throws Exception {
+    this.jimfsInputStreamTestTestRead_partialTemplate(10);
   }
 
   @Test
@@ -236,5 +228,13 @@ public class JimfsInputStreamTest {
     assertThat(in.read(new byte[3])).isEqualTo(-1);
     assertThat(in.read(new byte[10], 1, 5)).isEqualTo(-1);
     assertThat(in.available()).isEqualTo(0);
+  }
+
+  public void jimfsInputStreamTestTestRead_partialTemplate(int i1) throws Exception {
+    JimfsInputStream in = newInputStream(1, 2, 3, 4, 5, 6, 7, 8);
+    byte[] bytes = new byte[12];
+    assertThat(in.read(bytes, 0, i1)).isEqualTo(8);
+    assertArrayEquals(bytes(1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0), bytes);
+    assertEmpty(in);
   }
 }

--- a/jimfs/src/test/java/com/google/common/jimfs/PathNormalizationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathNormalizationTest.java
@@ -229,22 +229,12 @@ public class PathNormalizationTest {
 
   @Test
   public void testNormalizeNfc_pattern() {
-    normalizations = ImmutableSet.of(NFC);
-    assertNormalizedPatternMatches("foo", "foo");
-    assertNormalizedPatternDoesNotMatch("foo", "FOO");
-    assertNormalizedPatternDoesNotMatch("FOO", "foo");
-    assertNormalizedPatternMatches("Am\u00e9lie", "Ame\u0301lie");
-    assertNormalizedPatternDoesNotMatch("Am\u00e9lie", "AME\u0301LIE");
+    this.pathNormalizationTestTestNormalizeTemplate(NFC);
   }
 
   @Test
   public void testNormalizeNfd_pattern() {
-    normalizations = ImmutableSet.of(NFD);
-    assertNormalizedPatternMatches("foo", "foo");
-    assertNormalizedPatternDoesNotMatch("foo", "FOO");
-    assertNormalizedPatternDoesNotMatch("FOO", "foo");
-    assertNormalizedPatternMatches("Am\u00e9lie", "Ame\u0301lie");
-    assertNormalizedPatternDoesNotMatch("Am\u00e9lie", "AME\u0301LIE");
+    this.pathNormalizationTestTestNormalizeTemplate(NFD);
   }
 
   @Test
@@ -275,32 +265,12 @@ public class PathNormalizationTest {
 
   @Test
   public void testNormalizeNfcCaseFoldAscii_pattern() {
-    normalizations = ImmutableSet.of(NFC, CASE_FOLD_ASCII);
-    assertNormalizedPatternMatches("foo", "foo");
-    assertNormalizedPatternMatches("foo", "FOO");
-    assertNormalizedPatternMatches("FOO", "foo");
-
-    // these are all a bit fuzzy as when CASE_INSENSITIVE is present but not UNICODE_CASE, ASCII
-    // only strings are expected
-    assertNormalizedPatternMatches("Ame\u0301lie", "AME\u0301LIE");
-    assertNormalizedPatternDoesNotMatch("Am\u00e9lie", "AM\u00c9LIE");
-    assertNormalizedPatternMatches("Am\u00e9lie", "Ame\u0301lie");
-    assertNormalizedPatternMatches("AM\u00c9LIE", "AME\u0301LIE");
+    this.pathNormalizationTestTestNormalizeCaseFoldAscii_patternTemplate(NFC);
   }
 
   @Test
   public void testNormalizeNfdCaseFoldAscii_pattern() {
-    normalizations = ImmutableSet.of(NFD, CASE_FOLD_ASCII);
-    assertNormalizedPatternMatches("foo", "foo");
-    assertNormalizedPatternMatches("foo", "FOO");
-    assertNormalizedPatternMatches("FOO", "foo");
-
-    // these are all a bit fuzzy as when CASE_INSENSITIVE is present but not UNICODE_CASE, ASCII
-    // only strings are expected
-    assertNormalizedPatternMatches("Ame\u0301lie", "AME\u0301LIE");
-    assertNormalizedPatternDoesNotMatch("Am\u00e9lie", "AM\u00c9LIE");
-    assertNormalizedPatternMatches("Am\u00e9lie", "Ame\u0301lie");
-    assertNormalizedPatternMatches("AM\u00c9LIE", "AME\u0301LIE");
+    this.pathNormalizationTestTestNormalizeCaseFoldAscii_patternTemplate(NFD);
   }
 
   /** Asserts that the given strings normalize to the same string using the current normalizer. */
@@ -347,5 +317,25 @@ public class PathNormalizationTest {
     assertFalse(
         "pattern '" + pattern + "' should not match '" + first + "'",
         pattern.matcher(first).matches());
+  }
+
+  public void pathNormalizationTestTestNormalizeCaseFoldAscii_patternTemplate(PathNormalization pathNormalization1) {
+    normalizations = ImmutableSet.of(pathNormalization1, CASE_FOLD_ASCII);
+    assertNormalizedPatternMatches("foo", "foo");
+    assertNormalizedPatternMatches("foo", "FOO");
+    assertNormalizedPatternMatches("FOO", "foo");
+    assertNormalizedPatternMatches("Ame\u0301lie", "AME\u0301LIE");
+    assertNormalizedPatternDoesNotMatch("Am\u00e9lie", "AM\u00c9LIE");
+    assertNormalizedPatternMatches("Am\u00e9lie", "Ame\u0301lie");
+    assertNormalizedPatternMatches("AM\u00c9LIE", "AME\u0301LIE");
+  }
+
+  public void pathNormalizationTestTestNormalizeTemplate(PathNormalization pathNormalization1) {
+    normalizations = ImmutableSet.of(pathNormalization1);
+    assertNormalizedPatternMatches("foo", "foo");
+    assertNormalizedPatternDoesNotMatch("foo", "FOO");
+    assertNormalizedPatternDoesNotMatch("FOO", "foo");
+    assertNormalizedPatternMatches("Am\u00e9lie", "Ame\u0301lie");
+    assertNormalizedPatternDoesNotMatch("Am\u00e9lie", "AME\u0301LIE");
   }
 }

--- a/jimfs/src/test/java/com/google/common/jimfs/WindowsPathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/WindowsPathTypeTest.java
@@ -60,32 +60,12 @@ public class WindowsPathTypeTest {
 
   @Test
   public void testWindows_relativePathsWithDriveRoot_unsupported() {
-    try {
-      windows().parsePath("C:");
-      fail();
-    } catch (InvalidPathException expected) {
-    }
-
-    try {
-      windows().parsePath("C:foo\\bar");
-      fail();
-    } catch (InvalidPathException expected) {
-    }
+    this.windowsPathTypeTestTestTemplate("C:", "C:foo\\bar");
   }
 
   @Test
   public void testWindows_absolutePathOnCurrentDrive_unsupported() {
-    try {
-      windows().parsePath("\\foo\\bar");
-      fail();
-    } catch (InvalidPathException expected) {
-    }
-
-    try {
-      windows().parsePath("\\");
-      fail();
-    } catch (InvalidPathException expected) {
-    }
+    this.windowsPathTypeTestTestTemplate("\\foo\\bar", "\\");
   }
 
   @Test
@@ -218,5 +198,18 @@ public class WindowsPathTypeTest {
     assertUriRoundTripsCorrectly(PathType.windows(), "\\\\host\\share\\Users\\foo\\My Documents\\");
     assertUriRoundTripsCorrectly(PathType.windows(), "\\\\host\\share\\foo bar");
     assertUriRoundTripsCorrectly(PathType.windows(), "\\\\host\\share\\foo bar\\baz");
+  }
+
+  public void windowsPathTypeTestTestTemplate(String string1, String string2) {
+    try {
+      windows().parsePath(string1);
+      fail();
+    } catch (InvalidPathException expected) {
+    }
+    try {
+      windows().parsePath(string2);
+      fail();
+    } catch (InvalidPathException expected) {
+    }
   }
 }


### PR DESCRIPTION
As part of a research project at the University of Waterloo, we are exploring automatic test refactoring tools and submitting vetted proposed refactorings upstream. These refactorings make it easier to add additional related tests and should help with the maintainability of the tests.
These are all automated refactorings, but we have checked every case and made sure that all the test cases still pass successfully.
If it helps, we can also propose a test case that uses these refactored methods. We explained each of the four refactoring cases briefly below.

1) Test method pair "testRead_partialArray()" and "testRead_partialArray_sliceLarger()" only differ in an int value (8 vs 10). We create parametrized "jimfsInputStreamTestTestRead_partialTemplate(int i1)" method, which allows you to add similar test cases with different argument i1.

2) Test method pairs "testNormalizeNfc_pattern()" and "testNormalizeNfd_pattern()", and "testNormalizeNfcCaseFoldAscii_pattern()" and "testNormalizeNfdCaseFoldAscii_pattern()", only differ in a PathNormalization (NFC vs NFD). We create parametrized  "pathNormalizationTestTestNormalizeCaseFoldAscii_patternTemplate(PathNormalization pathNormalization1)" and "pathNormalizationTestTestNormalizeTemplate(PathNormalization pathNormalization1)" methods.

3) Test method pair "testWindows_relativePathsWithDriveRoot_unsupported()" and "testWindows_absolutePathOnCurrentDrive_unsupported()" only differ in two strings ("C:" vs "\\foo\\bar" and "C:foo\\bar" vs "\\"). We create parametrized "public void windowsPathTypeTestTestTemplate(String string1, String string2)" method.
