### PR TITLE
allow to write to PathURLConnection

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/PathURLConnection.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PathURLConnection.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterables;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -60,6 +61,7 @@ final class PathURLConnection extends URLConnection {
   private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
   private InputStream stream;
+  private OutputStream outStream;
   private ImmutableListMultimap<String, String> headers = ImmutableListMultimap.of();
 
   PathURLConnection(URL url) {
@@ -120,6 +122,16 @@ final class PathURLConnection extends URLConnection {
   public InputStream getInputStream() throws IOException {
     connect();
     return stream;
+  }
+
+  @Override
+  public OutputStream getOutputStream() throws IOException {
+    if (outStream == null) {
+      Path path = Paths.get(toUri(url));
+      Files.createDirectories(path.getParent());
+      outStream = Files.newOutputStream(path);
+    }
+    return outStream;
   }
 
   @SuppressWarnings("unchecked") // safe by specification of ListMultimap.asMap()


### PR DESCRIPTION
Hey,
we needed the ability to write to the PathURLConnection of jimfs for unit testing. The suggested change allowed us to use jimfs in the context of EMF (Eclipse Modeling Framework). 
We are not sure about the contract of getOutputStream, but for usual sockets there seems to be one stream, which will be reused for subsequent calls to getOutputStream (e.g. AbstractPlainSocketImpl).
A "try with resource" usage of the stream, would then close the stream and the next call to getOutputStream would return the closed stream. In our case this was not relevant and it is aligned with the getInputStream behavior. 
We have not opened the stream in the connect method, but only on demand in the getOutputStream method. 

It would be good, if this functionality (or enhanced implementation) could be added to the library.

Thanks
Janik