### PR TITLE
Add Automatic-Module-Name to JAR to provide JDK-9 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,18 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.google.jimfs</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Any builds on JDK-9 or newer that use modules and have this
dependency will currently produce a warning:

    Required filename-based automodules detected: [jimfs-1.2.jar]. Please don't publish this project to a public artifact repository!

This should address that issue. For all other purposes this JAR appears to work fine in Java 9
and newer (I am currently using it for a JDK-17-based project).