### PR TITLE
Refactored implementation and design smells in 

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
@@ -170,15 +170,11 @@ final class AttributeService {
 
   /** Copies the attributes of the given file to the given copy file. */
   public void copyAttributes(File file, File copy, AttributeCopyOption copyOption) {
-    switch (copyOption) {
-      case ALL:
-        file.copyAttributes(copy);
-        break;
-      case BASIC:
-        file.copyBasicAttributes(copy);
-        break;
-      default:
-        // don't copy
+    FileCopyOptions fileCopyOptions = CopyFactory.getCopyOption(copyOption);
+
+    // default: don't copy
+    if (fileCopyOptions != null) {
+      fileCopyOptions.copy(file, copy);
     }
   }
 
@@ -370,9 +366,11 @@ final class AttributeService {
     }
 
     // separator must not be at the start or end of the string or appear more than once
-    if (separatorIndex == 0
-        || separatorIndex == attribute.length() - 1
-        || attribute.indexOf(':', separatorIndex + 1) != -1) {
+    boolean separatorNotValid = separatorIndex == 0
+            || separatorIndex == attribute.length() - 1
+            || attribute.indexOf(':', separatorIndex + 1) != -1;
+
+    if (separatorNotValid) {
       throw new IllegalArgumentException("illegal attribute format: " + attribute);
     }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/CopyFactory.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/CopyFactory.java
@@ -1,0 +1,16 @@
+package com.google.common.jimfs;
+
+import java.util.HashMap;
+
+public class CopyFactory {
+    private static final HashMap<AttributeCopyOption, FileCopyOptions> copyMap = new HashMap<>();
+
+    static {
+        copyMap.put(AttributeCopyOption.ALL, new FileCopyAll());
+        copyMap.put(AttributeCopyOption.BASIC, new FileCopyBasic());
+    }
+
+    public static FileCopyOptions getCopyOption(AttributeCopyOption attributeCopyOption) {
+        return copyMap.get(attributeCopyOption);
+    }
+}

--- a/jimfs/src/main/java/com/google/common/jimfs/Directory.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Directory.java
@@ -79,7 +79,10 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
     return entryInParent.directory();
   }
 
-  @Override
+  /**
+   * Called when this file has been linked in a directory. The given entry is the new directory
+   * entry that links to this file.
+   */
   void linked(DirectoryEntry entry) {
     File parent = entry.directory(); // handles null check
     this.entryInParent = entry;
@@ -128,7 +131,8 @@ final class Directory extends File implements Iterable<DirectoryEntry> {
   public void link(Name name, File file) {
     DirectoryEntry entry = new DirectoryEntry(this, checkNotReserved(name, "link"), file);
     put(entry);
-    file.linked(entry);
+    // file.linked(entry);
+    linked(entry);
   }
 
   /**

--- a/jimfs/src/main/java/com/google/common/jimfs/File.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/File.java
@@ -136,9 +136,9 @@ public abstract class File {
    * Called when this file has been linked in a directory. The given entry is the new directory
    * entry that links to this file.
    */
-  void linked(DirectoryEntry entry) {
+  /* void linked(DirectoryEntry entry) {
     checkNotNull(entry);
-  }
+  } */
 
   /** Called when this file has been unlinked from a directory, either for a move or delete. */
   void unlinked() {}

--- a/jimfs/src/main/java/com/google/common/jimfs/FileCopyAll.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileCopyAll.java
@@ -1,0 +1,8 @@
+package com.google.common.jimfs;
+
+public class FileCopyAll implements FileCopyOptions {
+    @Override
+    public void copy(File file, File copy) {
+        file.copyAttributes(copy);
+    }
+}

--- a/jimfs/src/main/java/com/google/common/jimfs/FileCopyBasic.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileCopyBasic.java
@@ -1,0 +1,8 @@
+package com.google.common.jimfs;
+
+public class FileCopyBasic implements FileCopyOptions {
+    @Override
+    public void copy(File file, File copy) {
+        file.copyBasicAttributes(copy);
+    }
+}

--- a/jimfs/src/main/java/com/google/common/jimfs/FileCopyOptions.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileCopyOptions.java
@@ -1,0 +1,5 @@
+package com.google.common.jimfs;
+
+public interface FileCopyOptions {
+    void copy(File file, File copy);
+}

--- a/jimfs/src/main/java/com/google/common/jimfs/HeaderFormatter.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/HeaderFormatter.java
@@ -1,0 +1,22 @@
+package com.google.common.jimfs;
+
+import java.nio.file.attribute.FileTime;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * Class responsible for formatting the "last-modified" header according to the specified date format.
+ */
+public class HeaderFormatter {
+
+    private static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss 'GMT'";
+
+    static String formatLastModified(FileTime lastModified) {
+        DateFormat format = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
+        format.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return format.format(new Date(lastModified.toMillis()));
+    }
+}

--- a/jimfs/src/main/java/com/google/common/jimfs/Util.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/Util.java
@@ -76,19 +76,33 @@ final class Util {
   private static final byte[] ZERO_ARRAY = new byte[ARRAY_LEN];
   private static final byte[][] NULL_ARRAY = new byte[ARRAY_LEN][];
 
-  /** Zeroes all bytes between off (inclusive) and off + len (exclusive) in the given array. */
-  static void zero(byte[] bytes, int off, int len) {
+  /**
+   * Fills or clears all bytes between off (inclusive) and off + len (exclusive) in the given array.
+   *
+   * @param blocks    The array to be filled or cleared.
+   * @param off       The starting index (inclusive).
+   * @param len       The length of the slice to be filled or cleared.
+   * @param fillFlag  If true, fill with zero bytes; otherwise, clear the array elements.
+   */
+  static void fillOrClear(byte[][] blocks, int off, int len, boolean fillFlag) {
+    byte[] fillArray = fillFlag ? ZERO_ARRAY : NULL_ARRAY[0];
+
     // this is significantly faster than looping or Arrays.fill (which loops), particularly when
     // the length of the slice to be zeroed is <= to ARRAY_LEN (in that case, it's faster by a
     // factor of 2)
     int remaining = len;
     while (remaining > ARRAY_LEN) {
-      System.arraycopy(ZERO_ARRAY, 0, bytes, off, ARRAY_LEN);
+      System.arraycopy(fillArray, 0, blocks, off, ARRAY_LEN);
       off += ARRAY_LEN;
       remaining -= ARRAY_LEN;
     }
 
-    System.arraycopy(ZERO_ARRAY, 0, bytes, off, remaining);
+    System.arraycopy(fillArray, 0, blocks, off, remaining);
+  }
+
+  /** Zeroes all bytes between off (inclusive) and off + len (exclusive) in the given array. */
+  static void zero(byte[] bytes, int off, int len) {
+    fillOrClear(new byte[][]{bytes}, off, len, true);
   }
 
   /**
@@ -96,16 +110,6 @@ final class Util {
    * array.
    */
   static void clear(byte[][] blocks, int off, int len) {
-    // this is significantly faster than looping or Arrays.fill (which loops), particularly when
-    // the length of the slice to be cleared is <= to ARRAY_LEN (in that case, it's faster by a
-    // factor of 2)
-    int remaining = len;
-    while (remaining > ARRAY_LEN) {
-      System.arraycopy(NULL_ARRAY, 0, blocks, off, ARRAY_LEN);
-      off += ARRAY_LEN;
-      remaining -= ARRAY_LEN;
-    }
-
-    System.arraycopy(NULL_ARRAY, 0, blocks, off, remaining);
+    fillOrClear(blocks, off, len, false);
   }
 }

--- a/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
@@ -16,10 +16,7 @@
 
 package com.google.common.jimfs;
 
-import static com.google.common.jimfs.PathNormalization.CASE_FOLD_ASCII;
-import static com.google.common.jimfs.PathNormalization.CASE_FOLD_UNICODE;
-import static com.google.common.jimfs.PathNormalization.NFC;
-import static com.google.common.jimfs.PathNormalization.NFD;
+import static com.google.common.jimfs.PathNormalization.*;
 import static com.google.common.jimfs.PathSubject.paths;
 import static com.google.common.jimfs.WatchServiceConfiguration.polling;
 import static com.google.common.truth.Truth.assertThat;
@@ -167,6 +164,42 @@ public class ConfigurationTest {
       fail();
     } catch (FileAlreadyExistsException expected) {
     }
+  }
+
+  @Test
+  public void testBuilderForNone() {
+    AttributeProvider unixProvider = StandardAttributeProviders.get("unix");
+
+    FileTimeSource fileTimeSource = new FakeFileTimeSource();
+    Configuration config =
+            Configuration.builder(PathType.unix())
+                    .setRoots("/")
+                    .setWorkingDirectory("/hello/world")
+                    .setNameCanonicalNormalization(NONE)
+                    .setNameDisplayNormalization(NONE)
+                    .setPathEqualityUsesCanonicalForm(true)
+                    .setBlockSize(10)
+                    .setMaxSize(100)
+                    .setMaxCacheSize(50)
+                    .setAttributeViews("basic", "posix")
+                    .addAttributeProvider(unixProvider)
+                    .setDefaultAttributeValue(
+                            "posix:permissions", PosixFilePermissions.fromString("---------"))
+                    .setFileTimeSource(fileTimeSource)
+                    .build();
+
+    assertThat(config.pathType).isEqualTo(PathType.unix());
+    assertThat(config.roots).containsExactly("/");
+    assertThat(config.workingDirectory).isEqualTo("/hello/world");
+    assertThat(config.pathEqualityUsesCanonicalForm).isTrue();
+    assertThat(config.blockSize).isEqualTo(10);
+    assertThat(config.maxSize).isEqualTo(100);
+    assertThat(config.maxCacheSize).isEqualTo(50);
+    assertThat(config.attributeViews).containsExactly("basic", "posix");
+    assertThat(config.attributeProviders).containsExactly(unixProvider);
+    assertThat(config.defaultAttributeValues)
+            .containsEntry("posix:permissions", PosixFilePermissions.fromString("---------"));
+    assertThat(config.fileTimeSource).isEqualTo(fileTimeSource);
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/PathNormalizationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathNormalizationTest.java
@@ -127,7 +127,7 @@ public class PathNormalizationTest {
     }
   }
 
-  private static final String[][] NORMALIZE_CASE_FOLD_TEST_DATA = {
+  private static final String[][] NORM_CASE_FOLD_TEST_DATA = {
     {"\u00c5", "\u00e5", "\u212b"},
     {"Am\u00e9lie", "Am\u00c9lie", "Ame\u0301lie", "AME\u0301LIE"}
   };
@@ -136,7 +136,7 @@ public class PathNormalizationTest {
   public void testNormalizeNfcCaseFold() {
     normalizations = ImmutableSet.of(NFC, CASE_FOLD_UNICODE);
 
-    for (String[] row : NORMALIZE_CASE_FOLD_TEST_DATA) {
+    for (String[] row : NORM_CASE_FOLD_TEST_DATA) {
       for (int i = 0; i < row.length; i++) {
         for (int j = i; j < row.length; j++) {
           assertNormalizedEqual(row[i], row[j]);
@@ -149,7 +149,7 @@ public class PathNormalizationTest {
   public void testNormalizeNfdCaseFold() {
     normalizations = ImmutableSet.of(NFD, CASE_FOLD_UNICODE);
 
-    for (String[] row : NORMALIZE_CASE_FOLD_TEST_DATA) {
+    for (String[] row : NORM_CASE_FOLD_TEST_DATA) {
       for (int i = 0; i < row.length; i++) {
         for (int j = i; j < row.length; j++) {
           assertNormalizedEqual(row[i], row[j]);
@@ -158,7 +158,7 @@ public class PathNormalizationTest {
     }
   }
 
-  private static final String[][] NORMALIZED_CASE_INSENSITIVE_ASCII_TEST_DATA = {
+  private static final String[][] NORM_CASE_INSNSTV_ASCII_TEST_DATA = {
     {"\u00e5", "\u212b"},
     {"Am\u00e9lie", "AME\u0301LIE"}
   };
@@ -167,7 +167,7 @@ public class PathNormalizationTest {
   public void testNormalizeNfcCaseFoldAscii() {
     normalizations = ImmutableSet.of(NFC, CASE_FOLD_ASCII);
 
-    for (String[] row : NORMALIZED_CASE_INSENSITIVE_ASCII_TEST_DATA) {
+    for (String[] row : NORM_CASE_INSNSTV_ASCII_TEST_DATA) {
       for (int i = 0; i < row.length; i++) {
         for (int j = i + 1; j < row.length; j++) {
           assertNormalizedUnequal(row[i], row[j]);
@@ -180,7 +180,7 @@ public class PathNormalizationTest {
   public void testNormalizeNfdCaseFoldAscii() {
     normalizations = ImmutableSet.of(NFD, CASE_FOLD_ASCII);
 
-    for (String[] row : NORMALIZED_CASE_INSENSITIVE_ASCII_TEST_DATA) {
+    for (String[] row : NORM_CASE_INSNSTV_ASCII_TEST_DATA) {
       for (int i = 0; i < row.length; i++) {
         for (int j = i + 1; j < row.length; j++) {
           // since decomposition happens before case folding, the strings are equal when the

--- a/jimfs/src/test/java/com/google/common/jimfs/PathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathTypeTest.java
@@ -18,6 +18,8 @@ package com.google.common.jimfs;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.jimfs.PathType.ParseResult;
@@ -37,6 +39,20 @@ public class PathTypeTest {
 
   private static final FakePathType type = new FakePathType();
   static final URI fileSystemUri = URI.create("jimfs://foo");
+
+  @Test
+  public void testURIThrowsException() {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      URI fileSystemUri = URI.create("incorrect URI");
+      URI fileUri = type.toUri(fileSystemUri, "$", ImmutableList.of("test1", "test2"), false);
+    });
+
+    String expectedMessage = "Illegal character in path at index";
+    String actualMessage = exception.getMessage();
+
+    assertTrue(actualMessage.contains(expectedMessage));
+  }
+
 
   @Test
   public void testBasicProperties() {

--- a/jimfs/src/test/java/com/google/common/jimfs/UnixAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UnixAttributeProviderTest.java
@@ -49,6 +49,38 @@ public class UnixAttributeProviderTest
   }
 
   @Test
+  public void testDifferentPermissions() {
+    file.setAttribute(
+            "posix", "permissions", ImmutableSet.copyOf(PosixFilePermissions.fromString("rw-r--r--")));
+
+    assertThat(provider.get(file, "mode")).isEqualTo(0644);
+
+    file.setAttribute(
+            "posix", "permissions", ImmutableSet.copyOf(PosixFilePermissions.fromString("--x------")));
+    assertThat(provider.get(file, "mode")).isEqualTo(0100);
+
+    file.setAttribute(
+            "posix", "permissions", ImmutableSet.copyOf(PosixFilePermissions.fromString("----w----")));
+    assertThat(provider.get(file, "mode")).isEqualTo(0020);
+
+    file.setAttribute(
+            "posix", "permissions", ImmutableSet.copyOf(PosixFilePermissions.fromString("-----x---")));
+    assertThat(provider.get(file, "mode")).isEqualTo(0010);
+
+    file.setAttribute(
+            "posix", "permissions", ImmutableSet.copyOf(PosixFilePermissions.fromString("-------w-")));
+    assertThat(provider.get(file, "mode")).isEqualTo(0002);
+
+    file.setAttribute(
+            "posix", "permissions", ImmutableSet.copyOf(PosixFilePermissions.fromString("--------x")));
+    assertThat(provider.get(file, "mode")).isEqualTo(0001);
+
+    file.setAttribute(
+            "posix", "permissions", ImmutableSet.copyOf(PosixFilePermissions.fromString("r--r--rw-")));
+    assertThat(provider.get(file, "mode")).isEqualTo(0446);
+  }
+
+  @Test
   public void testInitialAttributes() {
     // unix provider relies on other providers to set their initial attributes
     file.setAttribute("owner", "owner", createUserPrincipal("foo"));

--- a/jimfs/src/test/java/com/google/common/jimfs/UtilsTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UtilsTest.java
@@ -1,0 +1,21 @@
+package com.google.common.jimfs;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UtilsTest {
+    @Test
+    public void testPowerOf2() {
+        assertEquals(1, Util.nextPowerOf2(0));
+        assertEquals(1, Util.nextPowerOf2(1));
+        assertEquals(2, Util.nextPowerOf2(2));
+        assertEquals(4, Util.nextPowerOf2(3));
+        assertEquals(4, Util.nextPowerOf2(4));
+        assertEquals(8, Util.nextPowerOf2(5));
+
+        // When power provided is negative
+        assertEquals(0, Util.nextPowerOf2(-5));
+        assertEquals(0, Util.nextPowerOf2(-10));
+    }
+}


### PR DESCRIPTION
Fixed code smells in several files:
- AttributeService - Introduced explaining variable and applied polymorphism for switch case
- Directory - Removed linked() method from the File parent class
- PathNormalizationTest - Renamed variables to remove Long Identifier smell
- PathURLConnection - Extracted a class HeaderFormatter and updated header formatting logic accordingly
- Util.java - Created a method fillOrClear to remove duplicate code used in zero and clear functions