### PR TITLE
Move error_prone_core out of the common annotation processor path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,11 +216,6 @@
           <target>${java.version}</target>
           <annotationProcessorPaths>
             <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${errorprone.version}</version>
-            </path>
-            <path>
               <groupId>com.google.guava</groupId>
               <artifactId>guava-beta-checker</artifactId>
               <version>1.0</version>
@@ -317,6 +312,13 @@
               <compilerArgument>-Xplugin:ErrorProne -Xep:Java8ApiChecker:ERROR</compilerArgument>
               <!-- Disable Beta Checker for tests -->
               <testCompilerArgument>-Xplugin:ErrorProne -Xep:BetaApi:OFF</testCompilerArgument>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </path>
+              </annotationProcessorPaths>
               <compilerArgs>
                 <!-- https://errorprone.info/docs/installation#maven -->
                 <arg>-XDcompilePolicy=simple</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -216,11 +216,6 @@
           <target>${java.version}</target>
           <annotationProcessorPaths>
             <path>
-              <groupId>com.google.guava</groupId>
-              <artifactId>guava-beta-checker</artifactId>
-              <version>1.0</version>
-            </path>
-            <path>
               <groupId>com.google.auto.service</groupId>
               <artifactId>auto-service</artifactId>
               <version>${auto-service.version}</version>
@@ -312,11 +307,16 @@
               <compilerArgument>-Xplugin:ErrorProne -Xep:Java8ApiChecker:ERROR</compilerArgument>
               <!-- Disable Beta Checker for tests -->
               <testCompilerArgument>-Xplugin:ErrorProne -Xep:BetaApi:OFF</testCompilerArgument>
-              <annotationProcessorPaths>
+              <annotationProcessorPaths combine.children="append">
                 <path>
                   <groupId>com.google.errorprone</groupId>
                   <artifactId>error_prone_core</artifactId>
                   <version>${errorprone.version}</version>
+                </path>
+                <path>
+                  <groupId>com.google.guava</groupId>
+                  <artifactId>guava-beta-checker</artifactId>
+                  <version>1.0</version>
                 </path>
               </annotationProcessorPaths>
               <compilerArgs>


### PR DESCRIPTION
This change moves `error_prone_core` from the common `annotationProcessorPaths` to the Maven compiler configuration that explicitly enables Error Prone. Commit `6faa637b19b13b9a816e7896a0605625ea422e7a` updated Error Prone from 2.42.0 to 2.43.0, after which the OSS-Fuzz JDK 17 build attempted to load the Java 21 `ErrorProneJavacPlugin` and failed with `UnsupportedClassVersionError`; a counterfactual build confirmed that the parent revision succeeds under the same configuration. Scoping `error_prone_core` to the configuration that uses `-Xplugin:ErrorProne` prevents the common compiler configuration from exposing the incompatible plugin while retaining it where Error Prone is explicitly enabled. The patched OSS-Fuzz target builds successfully and passes `check_build`.
