### PR TITLE
Migrate tests from JUnit 4 to JUnit 5

### DIFF
--- a/jimfs/pom.xml
+++ b/jimfs/pom.xml
@@ -68,8 +68,8 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractAttributeProviderTest.java
@@ -17,14 +17,14 @@
 package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.nio.file.attribute.FileAttributeView;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Abstract base class for tests of individual {@link AttributeProvider} implementations.
@@ -56,7 +56,7 @@ public abstract class AbstractAttributeProviderTest<P extends AttributeProvider>
     };
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.provider = createProvider();
     this.file = Directory.create(0, fileTimeSource.now());
@@ -115,21 +115,15 @@ public abstract class AbstractAttributeProviderTest<P extends AttributeProvider>
     assertSetAndGetSucceeds(attribute, value, true);
   }
 
-  @SuppressWarnings("EmptyCatchBlock")
   protected void assertSetFails(String attribute, Object value) {
-    try {
-      provider.set(file, provider.name(), attribute, value, false);
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> provider.set(file, provider.name(), attribute, value, false));
   }
 
-  @SuppressWarnings("EmptyCatchBlock")
   protected void assertSetFailsOnCreate(String attribute, Object value) {
-    try {
-      provider.set(file, provider.name(), attribute, value, true);
-      fail();
-    } catch (UnsupportedOperationException expected) {
-    }
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> provider.set(file, provider.name(), attribute, value, true));
   }
 }

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractGlobMatcherTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractGlobMatcherTest.java
@@ -16,7 +16,7 @@
 
 package com.google.common.jimfs;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** @author Colin Decker */
 public abstract class AbstractGlobMatcherTest extends AbstractPathMatcherTest {

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractJimfsIntegrationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractJimfsIntegrationTest.java
@@ -27,20 +27,20 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /** @author Colin Decker */
 public abstract class AbstractJimfsIntegrationTest {
 
   protected FileSystem fs;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     fs = createFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     fs.close();
   }

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractPathMatcherTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractPathMatcherTest.java
@@ -16,9 +16,10 @@
 
 package com.google.common.jimfs;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.File;
@@ -54,11 +55,7 @@ public abstract class AbstractPathMatcherTest {
   }
 
   protected void assertSyntaxError(String pattern) {
-    try {
-      matcher(pattern);
-      fail();
-    } catch (PatternSyntaxException expected) {
-    }
+    assertThrows(PatternSyntaxException.class, () -> matcher(pattern));
 
     try {
       PathMatcher real = realMatcher(pattern);
@@ -88,12 +85,13 @@ public abstract class AbstractPathMatcherTest {
     PatternAsserter matches(String... paths) {
       for (String path : paths) {
         assertTrue(
-            "matcher '" + matcher + "' did not match '" + path + "'", matcher.matches(fake(path)));
+            matcher.matches(fake(path)),
+            "matcher '" + matcher + "' did not match '" + path + "'");
         if (realMatcher != null) {
           Path realPath = Paths.get(path);
           assertTrue(
-              "real matcher '" + realMatcher + "' did not match '" + realPath + "'",
-              realMatcher.matches(realPath));
+              realMatcher.matches(realPath),
+              "real matcher '" + realMatcher + "' did not match '" + realPath + "'");
         }
       }
       return this;
@@ -103,13 +101,13 @@ public abstract class AbstractPathMatcherTest {
     PatternAsserter doesNotMatch(String... paths) {
       for (String path : paths) {
         assertFalse(
-            "glob '" + matcher + "' should not have matched '" + path + "'",
-            matcher.matches(fake(path)));
+            matcher.matches(fake(path)),
+            "glob '" + matcher + "' should not have matched '" + path + "'");
         if (realMatcher != null) {
           Path realPath = Paths.get(path);
           assertFalse(
-              "real matcher '" + realMatcher + "' matched '" + realPath + "'",
-              realMatcher.matches(realPath));
+              realMatcher.matches(realPath),
+              "real matcher '" + realMatcher + "' matched '" + realPath + "'");
         }
       }
       return this;

--- a/jimfs/src/test/java/com/google/common/jimfs/AbstractWatchServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AbstractWatchServiceTest.java
@@ -24,7 +24,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -37,22 +37,19 @@ import java.nio.file.WatchService;
 import java.nio.file.Watchable;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link AbstractWatchService}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class AbstractWatchServiceTest {
 
   private AbstractWatchService watcher;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     watcher = new AbstractWatchService() {};
   }

--- a/jimfs/src/test/java/com/google/common/jimfs/AclAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AclAttributeProviderTest.java
@@ -22,7 +22,7 @@ import static java.nio.file.attribute.AclEntryFlag.DIRECTORY_INHERIT;
 import static java.nio.file.attribute.AclEntryPermission.APPEND_DATA;
 import static java.nio.file.attribute.AclEntryPermission.DELETE;
 import static java.nio.file.attribute.AclEntryType.ALLOW;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -34,16 +34,13 @@ import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link AclAttributeProvider}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class AclAttributeProviderTest extends AbstractAttributeProviderTest<AclAttributeProvider> {
 
   private static final UserPrincipal USER = createUserPrincipal("user");

--- a/jimfs/src/test/java/com/google/common/jimfs/AttributeServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AttributeServiceTest.java
@@ -17,7 +17,7 @@
 package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -28,24 +28,21 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link AttributeService}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class AttributeServiceTest {
 
   private AttributeService service;
 
   private final FakeFileTimeSource fileTimeSource = new FakeFileTimeSource();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     ImmutableSet<AttributeProvider> providers =
         ImmutableSet.of(

--- a/jimfs/src/test/java/com/google/common/jimfs/BasicAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/BasicAttributeProviderTest.java
@@ -25,16 +25,13 @@ import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link BasicAttributeProvider}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class BasicAttributeProviderTest
     extends AbstractAttributeProviderTest<BasicAttributeProvider> {
 

--- a/jimfs/src/test/java/com/google/common/jimfs/ClassLoaderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ClassLoaderTest.java
@@ -17,9 +17,9 @@
 package com.google.common.jimfs;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -31,9 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests behavior when user code loads Jimfs in a separate class loader from the system class loader
@@ -42,7 +40,6 @@ import org.junit.runners.JUnit4;
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class ClassLoaderTest {
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
@@ -26,8 +26,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -38,9 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.PosixFilePermissions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link Configuration}, {@link Configuration.Builder} and file systems created from
@@ -48,7 +45,6 @@ import org.junit.runners.JUnit4;
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class ConfigurationTest {
 
   private static PathSubject assertThatPath(Path path) {
@@ -268,11 +264,9 @@ public class ConfigurationTest {
   }
 
   private static void assertIllegalRoots(PathType type, String first, String... more) {
-    try {
-      Configuration.builder(type).setRoots(first, more); // wrong root
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Configuration.builder(type).setRoots(first, more)); // wrong root
   }
 
   @Test
@@ -296,17 +290,13 @@ public class ConfigurationTest {
 
   private static void assertIllegalNormalizations(
       PathNormalization first, PathNormalization... more) {
-    try {
-      Configuration.builder(PathType.unix()).setNameCanonicalNormalization(first, more);
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Configuration.builder(PathType.unix()).setNameCanonicalNormalization(first, more));
 
-    try {
-      Configuration.builder(PathType.unix()).setNameDisplayNormalization(first, more);
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Configuration.builder(PathType.unix()).setNameDisplayNormalization(first, more));
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/CrossClassLoaderAccessTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/CrossClassLoaderAccessTest.java
@@ -21,7 +21,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test that the {@code toPath} method of {@link SystemJimfsFileSystemProvider} handles the case

--- a/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/DirectoryTest.java
@@ -20,7 +20,7 @@ import static com.google.common.jimfs.Name.PARENT;
 import static com.google.common.jimfs.Name.SELF;
 import static com.google.common.jimfs.TestUtils.regularFile;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableSet;
@@ -29,17 +29,14 @@ import com.google.common.collect.Iterables;
 import java.util.HashSet;
 import java.util.Set;
 import org.jspecify.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link Directory}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class DirectoryTest {
 
   private final FakeFileTimeSource fileTimeSource = new FakeFileTimeSource();
@@ -47,7 +44,7 @@ public class DirectoryTest {
   private Directory root;
   private Directory dir;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     root = Directory.createRoot(0, fileTimeSource.now(), Name.simple("/"));
 

--- a/jimfs/src/test/java/com/google/common/jimfs/DosAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/DosAttributeProviderTest.java
@@ -17,7 +17,7 @@
 package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -28,16 +28,13 @@ import java.nio.file.attribute.DosFileAttributes;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link DosAttributeProvider}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class DosAttributeProviderTest extends AbstractAttributeProviderTest<DosAttributeProvider> {
 
   private static final ImmutableList<String> DOS_ATTRIBUTES =

--- a/jimfs/src/test/java/com/google/common/jimfs/FileFactoryTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/FileFactoryTest.java
@@ -18,24 +18,21 @@ package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link FileFactory}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class FileFactoryTest {
 
   private final FakeFileTimeSource fileTimeSource = new FakeFileTimeSource();
 
   private FileFactory factory;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     factory = new FileFactory(new HeapDisk(2, 2, 0), fileTimeSource);
   }

--- a/jimfs/src/test/java/com/google/common/jimfs/FileSystemStateTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/FileSystemStateTest.java
@@ -17,10 +17,10 @@
 package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -29,16 +29,13 @@ import java.io.IOException;
 import java.nio.file.ClosedFileSystemException;
 import java.time.Duration;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link FileSystemState}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class FileSystemStateTest {
 
   private final TestRunnable onClose = new TestRunnable();

--- a/jimfs/src/test/java/com/google/common/jimfs/FileTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/FileTest.java
@@ -20,16 +20,13 @@ import static com.google.common.jimfs.FileFactoryTest.fakePath;
 import static com.google.common.jimfs.TestUtils.regularFile;
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link File}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class FileTest {
 
   private final FakeFileTimeSource fileTimeSource = new FakeFileTimeSource();

--- a/jimfs/src/test/java/com/google/common/jimfs/FileTreeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/FileTreeTest.java
@@ -20,8 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.jimfs.TestUtils.regularFile;
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -34,17 +33,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import org.jspecify.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link FileTree}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class FileTreeTest {
 
   /*
@@ -117,7 +113,7 @@ public class FileTreeTest {
   private File workingDirectory;
   private final Map<String, File> files = new HashMap<>();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     Directory root = Directory.createRoot(0, fileTimeSource.now(), Name.simple("/"));
     files.put("/", root);
@@ -373,11 +369,7 @@ public class FileTreeTest {
     assertThat(entry.exists()).isFalse();
     assertThat(entry.directory()).isEqualTo(files.get(parent));
 
-    try {
-      entry.file();
-      fail();
-    } catch (IllegalStateException expected) {
-    }
+    assertThrows(IllegalStateException.class, () -> entry.file());
   }
 
   @CanIgnoreReturnValue

--- a/jimfs/src/test/java/com/google/common/jimfs/HeapDiskTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/HeapDiskTest.java
@@ -17,29 +17,26 @@
 package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link HeapDisk}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class HeapDiskTest {
 
   private final FakeFileTimeSource fileTimeSource = new FakeFileTimeSource();
 
   private RegularFile blocks;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     // the HeapDisk of this file is unused; it's passed to other HeapDisks to test operations
     blocks = RegularFile.create(-1, fileTimeSource.now(), new HeapDisk(2, 2, 2));

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsAsynchronousFileChannelTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsAsynchronousFileChannelTest.java
@@ -23,11 +23,11 @@ import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Runnables;
@@ -45,16 +45,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link JimfsAsynchronousFileChannel}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class JimfsAsynchronousFileChannelTest {
 
   private static JimfsAsynchronousFileChannel channel(

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsFileChannelTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsFileChannelTest.java
@@ -25,13 +25,13 @@ import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.NullPointerTester;
@@ -59,9 +59,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Most of the behavior of {@link JimfsFileChannel} is handled by the {@link RegularFile}
@@ -70,7 +69,6 @@ import org.junit.runners.JUnit4;
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class JimfsFileChannelTest {
 
   private static FileChannel channel(RegularFile file, OpenOption... options) throws IOException {
@@ -545,7 +543,7 @@ public class JimfsFileChannelTest {
   }
 
   @Test
-  @org.junit.Ignore // flaky
+  @Disabled // flaky
   public void testCloseByInterrupt() throws Exception {
     RegularFile file = regularFile(10);
     final FileChannel channel = channel(file, READ, WRITE);
@@ -879,8 +877,8 @@ public class JimfsFileChannelTest {
           "expected the method to throw ClosedByInterruptException or "
               + "FileLockInterruptionException");
     } catch (ClosedByInterruptException | FileLockInterruptionException expected) {
-      assertFalse("expected the channel to be closed", channel.isOpen());
-      assertTrue("expected the thread to still be interrupted", Thread.interrupted());
+      assertFalse(channel.isOpen(), "expected the channel to be closed");
+      assertTrue(Thread.interrupted(), "expected the thread to still be interrupted");
     } finally {
       Thread.interrupted(); // ensure the thread isn't interrupted when this method returns
     }

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsFileSystemCloseTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsFileSystemCloseTest.java
@@ -24,11 +24,11 @@ import static java.nio.file.StandardOpenOption.WRITE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -51,16 +51,13 @@ import java.nio.file.WatchService;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for what happens when a file system is closed.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class JimfsFileSystemCloseTest {
 
   private JimfsFileSystem fs = (JimfsFileSystem) Jimfs.newFileSystem(Configuration.unix());

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsInputStreamTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsInputStreamTest.java
@@ -19,21 +19,18 @@ package com.google.common.jimfs;
 import static com.google.common.jimfs.TestUtils.bytes;
 import static com.google.common.jimfs.TestUtils.regularFile;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.util.concurrent.Runnables;
 import java.io.IOException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link JimfsInputStream}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 @SuppressWarnings("ResultOfMethodCallIgnored")
 public class JimfsInputStreamTest {
 

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsOutputStreamTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsOutputStreamTest.java
@@ -19,23 +19,20 @@ package com.google.common.jimfs;
 import static com.google.common.jimfs.TestUtils.bytes;
 import static com.google.common.jimfs.TestUtils.regularFile;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.util.concurrent.Runnables;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link JimfsOutputStream}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class JimfsOutputStreamTest {
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsPathTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsPathTest.java
@@ -16,8 +16,8 @@
 
 package com.google.common.jimfs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
@@ -25,16 +25,13 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link JimfsPath}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class JimfsPathTest {
 
   private final PathService pathService = PathServiceTest.fakeUnixPathService();

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
@@ -36,11 +36,11 @@ import static java.nio.file.StandardOpenOption.SYNC;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -92,9 +92,7 @@ import java.nio.file.attribute.UserPrincipal;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.regex.PatternSyntaxException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests an in-memory file system through the public APIs in {@link Files}, etc. This also acts as
@@ -106,7 +104,6 @@ import org.junit.runners.JUnit4;
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
   private static final Configuration UNIX_CONFIGURATION =

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsWindowsLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsWindowsLikeFileSystemTest.java
@@ -18,7 +18,7 @@ package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -30,16 +30,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.regex.PatternSyntaxException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests a Windows-like file system through the public methods in {@link Files}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class JimfsWindowsLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
   @Override

--- a/jimfs/src/test/java/com/google/common/jimfs/NameTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/NameTest.java
@@ -18,16 +18,13 @@ package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link Name}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class NameTest {
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/OwnerAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/OwnerAttributeProviderTest.java
@@ -23,16 +23,13 @@ import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.attribute.FileOwnerAttributeView;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link OwnerAttributeProvider}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class OwnerAttributeProviderTest
     extends AbstractAttributeProviderTest<OwnerAttributeProvider> {
 

--- a/jimfs/src/test/java/com/google/common/jimfs/PathNormalizationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathNormalizationTest.java
@@ -21,22 +21,19 @@ import static com.google.common.jimfs.PathNormalization.CASE_FOLD_UNICODE;
 import static com.google.common.jimfs.PathNormalization.NFC;
 import static com.google.common.jimfs.PathNormalization.NFD;
 import static com.google.common.jimfs.TestUtils.assertNotEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PathNormalization}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class PathNormalizationTest {
 
   private ImmutableSet<PathNormalization> normalizations;
@@ -324,13 +321,13 @@ public class PathNormalizationTest {
   private void assertNormalizedPatternMatches(String first, String second) {
     Pattern pattern = PathNormalization.compilePattern(first, normalizations);
     assertTrue(
-        "pattern '" + pattern + "' does not match '" + second + "'",
-        pattern.matcher(second).matches());
+        pattern.matcher(second).matches(),
+        "pattern '" + pattern + "' does not match '" + second + "'");
 
     pattern = PathNormalization.compilePattern(second, normalizations);
     assertTrue(
-        "pattern '" + pattern + "' does not match '" + first + "'",
-        pattern.matcher(first).matches());
+        pattern.matcher(first).matches(),
+        "pattern '" + pattern + "' does not match '" + first + "'");
   }
 
   /**
@@ -340,12 +337,12 @@ public class PathNormalizationTest {
   private void assertNormalizedPatternDoesNotMatch(String first, String second) {
     Pattern pattern = PathNormalization.compilePattern(first, normalizations);
     assertFalse(
-        "pattern '" + pattern + "' should not match '" + second + "'",
-        pattern.matcher(second).matches());
+        pattern.matcher(second).matches(),
+        "pattern '" + pattern + "' should not match '" + second + "'");
 
     pattern = PathNormalization.compilePattern(second, normalizations);
     assertFalse(
-        "pattern '" + pattern + "' should not match '" + first + "'",
-        pattern.matcher(first).matches());
+        pattern.matcher(first).matches(),
+        "pattern '" + pattern + "' should not match '" + first + "'");
   }
 }

--- a/jimfs/src/test/java/com/google/common/jimfs/PathServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathServiceTest.java
@@ -27,16 +27,13 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.PathMatcher;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PathService}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class PathServiceTest {
 
   private static final ImmutableSet<PathNormalization> NO_NORMALIZATIONS = ImmutableSet.of();

--- a/jimfs/src/test/java/com/google/common/jimfs/PathTester.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathTester.java
@@ -17,11 +17,11 @@
 package com.google.common.jimfs;
 
 import static com.google.common.base.Functions.toStringFunction;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -80,12 +80,12 @@ public final class PathTester {
 
   private void testRoot(Path path) {
     if (root != null) {
-      assertTrue(path + ".isAbsolute() should be true", path.isAbsolute());
-      assertNotNull(path + ".getRoot() should not be null", path.getRoot());
+      assertTrue(path.isAbsolute(), path + ".isAbsolute() should be true");
+      assertNotNull(path.getRoot(), path + ".getRoot() should not be null");
       assertEquals(root, path.getRoot().toString());
     } else {
-      assertFalse(path + ".isAbsolute() should be false", path.isAbsolute());
-      assertNull(path + ".getRoot() should be null", path.getRoot());
+      assertFalse(path.isAbsolute(), path + ".isAbsolute() should be false");
+      assertNull(path.getRoot(), path + ".getRoot() should be null");
     }
   }
 
@@ -158,9 +158,10 @@ public final class PathTester {
     if (root != null || !names.isEmpty()) {
       Path other = path;
       while (other != null) {
-        assertTrue(path + ".startsWith(" + other + ") should be true", path.startsWith(other));
+        assertTrue(path.startsWith(other), path + ".startsWith(" + other + ") should be true");
         assertTrue(
-            path + ".startsWith(" + other + ") should be true", path.startsWith(other.toString()));
+            path.startsWith(other.toString()),
+            path + ".startsWith(" + other + ") should be true");
         other = other.getParent();
       }
     }
@@ -171,9 +172,10 @@ public final class PathTester {
     if (root != null || !names.isEmpty()) {
       Path other = path;
       while (other != null) {
-        assertTrue(path + ".endsWith(" + other + ") should be true", path.endsWith(other));
+        assertTrue(path.endsWith(other), path + ".endsWith(" + other + ") should be true");
         assertTrue(
-            path + ".endsWith(" + other + ") should be true", path.endsWith(other.toString()));
+            path.endsWith(other.toString()),
+            path + ".endsWith(" + other + ") should be true");
         if (other.getRoot() != null && other.getNameCount() > 0) {
           other = other.subpath(0, other.getNameCount());
         } else if (other.getNameCount() > 1) {

--- a/jimfs/src/test/java/com/google/common/jimfs/PathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PathTypeTest.java
@@ -23,16 +23,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.jimfs.PathType.ParseResult;
 import java.net.URI;
 import org.jspecify.annotations.Nullable;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PathType}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class PathTypeTest {
 
   private static final FakePathType type = new FakePathType();

--- a/jimfs/src/test/java/com/google/common/jimfs/PollingWatchServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PollingWatchServiceTest.java
@@ -21,7 +21,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.jimfs.AbstractWatchService.Event;
@@ -38,24 +38,23 @@ import java.nio.file.WatchKey;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests for {@link PollingWatchService}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class PollingWatchServiceTest {
 
   private JimfsFileSystem fs;
   private PollingWatchService watcher;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     fs = (JimfsFileSystem) Jimfs.newFileSystem(Configuration.unix());
     watcher =
@@ -67,7 +66,7 @@ public class PollingWatchServiceTest {
             MILLISECONDS);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     watcher.close();
     fs.close();
@@ -142,7 +141,8 @@ public class PollingWatchServiceTest {
     assertThat(watcher.isPolling()).isFalse();
   }
 
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testWatchForOneEventType() throws IOException, InterruptedException {
     JimfsPath path = createDirectory();
     watcher.register(path, ImmutableList.of(ENTRY_CREATE));
@@ -159,7 +159,8 @@ public class PollingWatchServiceTest {
         new Event<>(ENTRY_CREATE, 1, fs.getPath("baz")));
   }
 
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testWatchForMultipleEventTypes() throws IOException, InterruptedException {
     JimfsPath path = createDirectory();
     watcher.register(path, ImmutableList.of(ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY));

--- a/jimfs/src/test/java/com/google/common/jimfs/PosixAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PosixAttributeProviderTest.java
@@ -19,7 +19,7 @@ package com.google.common.jimfs;
 import static com.google.common.jimfs.UserLookupService.createGroupPrincipal;
 import static com.google.common.jimfs.UserLookupService.createUserPrincipal;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -30,16 +30,13 @@ import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PosixAttributeProvider}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class PosixAttributeProviderTest
     extends AbstractAttributeProviderTest<PosixAttributeProvider> {
 

--- a/jimfs/src/test/java/com/google/common/jimfs/RegexGlobMatcherTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/RegexGlobMatcherTest.java
@@ -16,23 +16,20 @@
 
 package com.google.common.jimfs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PathMatcher} instances created by {@link GlobToRegex}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class RegexGlobMatcherTest extends AbstractGlobMatcherTest {
 
   @Override

--- a/jimfs/src/test/java/com/google/common/jimfs/RegularFileBlocksTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/RegularFileBlocksTest.java
@@ -22,17 +22,14 @@ import com.google.common.primitives.Bytes;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the lower-level operations dealing with the blocks of a {@link RegularFile}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class RegularFileBlocksTest {
 
   private static final int BLOCK_SIZE = 2;
@@ -41,7 +38,7 @@ public class RegularFileBlocksTest {
 
   private RegularFile file;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     file = createFile();
   }

--- a/jimfs/src/test/java/com/google/common/jimfs/RegularFileTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/RegularFileTest.java
@@ -20,7 +20,7 @@ import static com.google.common.jimfs.TestUtils.buffer;
 import static com.google.common.jimfs.TestUtils.buffers;
 import static com.google.common.jimfs.TestUtils.bytes;
 import static com.google.common.primitives.Bytes.concat;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;

--- a/jimfs/src/test/java/com/google/common/jimfs/TestUtils.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/TestUtils.java
@@ -17,7 +17,7 @@
 package com.google.common.jimfs;
 
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -129,7 +129,8 @@ public final class TestUtils {
   // equivalent to the Junit 4.11 method.
   public static void assertNotEquals(Object unexpected, Object actual) {
     assertFalse(
-        "Values should be different. Actual: " + actual, Objects.equals(unexpected, actual));
+        Objects.equals(unexpected, actual),
+        "Values should be different. Actual: " + actual);
   }
 
   static RegularFile regularFile(int size) {

--- a/jimfs/src/test/java/com/google/common/jimfs/UnixAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UnixAttributeProviderTest.java
@@ -23,16 +23,13 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link UnixAttributeProvider}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 @SuppressWarnings("OctalInteger")
 public class UnixAttributeProviderTest
     extends AbstractAttributeProviderTest<UnixAttributeProvider> {

--- a/jimfs/src/test/java/com/google/common/jimfs/UnixPathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UnixPathTypeTest.java
@@ -20,22 +20,19 @@ import static com.google.common.jimfs.PathTypeTest.assertParseResult;
 import static com.google.common.jimfs.PathTypeTest.assertUriRoundTripsCorrectly;
 import static com.google.common.jimfs.PathTypeTest.fileSystemUri;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.nio.file.InvalidPathException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link UnixPathType}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class UnixPathTypeTest {
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/UrlTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UrlTest.java
@@ -31,16 +31,13 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that {@link URL} instances can be created and used from jimfs URIs.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class UrlTest {
 
   private final FileSystem fs = Jimfs.newFileSystem(Configuration.unix());

--- a/jimfs/src/test/java/com/google/common/jimfs/UserDefinedAttributeProviderTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UserDefinedAttributeProviderTest.java
@@ -17,8 +17,8 @@
 package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -27,16 +27,13 @@ import java.nio.ByteBuffer;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Arrays;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link UserDefinedAttributeProvider}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class UserDefinedAttributeProviderTest
     extends AbstractAttributeProviderTest<UserDefinedAttributeProvider> {
 

--- a/jimfs/src/test/java/com/google/common/jimfs/UserLookupServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/UserLookupServiceTest.java
@@ -17,23 +17,20 @@
 package com.google.common.jimfs;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.attribute.UserPrincipalNotFoundException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link UserLookupService}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class UserLookupServiceTest {
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/WatchServiceConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/WatchServiceConfigurationTest.java
@@ -22,30 +22,27 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.IOException;
 import java.nio.file.WatchService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link WatchServiceConfiguration}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class WatchServiceConfigurationTest {
 
   private JimfsFileSystem fs;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     // kind of putting the cart before the horse maybe, but it's the easiest way to get valid
     // instances of both a FileSystemView and a PathService
     fs = (JimfsFileSystem) Jimfs.newFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     fs.close();
     fs = null;

--- a/jimfs/src/test/java/com/google/common/jimfs/WindowsPathTypeTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/WindowsPathTypeTest.java
@@ -21,21 +21,18 @@ import static com.google.common.jimfs.PathTypeTest.assertParseResult;
 import static com.google.common.jimfs.PathTypeTest.assertUriRoundTripsCorrectly;
 import static com.google.common.jimfs.PathTypeTest.fileSystemUri;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.nio.file.InvalidPathException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link WindowsPathType}.
  *
  * @author Colin Decker
  */
-@RunWith(JUnit4.class)
 public class WindowsPathTypeTest {
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,9 @@
 
       <!-- Test dependencies -->
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.13.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Migrates the test suite to JUnit 5 (`junit-jupiter`).

All tests pass locally.