### PR TITLE
Throw UnsupportedOperationException for unsupported attribute views

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/AttributeService.java
@@ -308,6 +308,11 @@ final class AttributeService {
   /** Implements {@link Files#readAttributes(Path, String, LinkOption...)}. */
   public ImmutableMap<String, Object> readAttributes(File file, String attributes) {
     String view = getViewName(attributes);
+    AttributeProvider provider = providersByName.get(view);
+    if (provider == null) {
+      throw new UnsupportedOperationException("unsupported attribute view: " + view);
+    }
+
     List<String> attrs = getAttributeNames(attributes);
 
     if (attrs.size() > 1 && attrs.contains(ALL_ATTRIBUTES)) {
@@ -318,7 +323,6 @@ final class AttributeService {
     Map<String, Object> result = new HashMap<>();
     if (attrs.size() == 1 && attrs.contains(ALL_ATTRIBUTES)) {
       // for 'view:*' format, get all keys for all providers for the view
-      AttributeProvider provider = providersByName.get(view);
       readAll(file, provider, result);
 
       for (String inheritedView : provider.inherits()) {

--- a/jimfs/src/test/java/com/google/common/jimfs/AttributeServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/AttributeServiceTest.java
@@ -337,6 +337,13 @@ public class AttributeServiceTest {
   }
 
   @Test
+  public void testReadAttributes_failsForUnsupportedAttributeView() {
+    File file = createFile();
+    assertThrows(
+        UnsupportedOperationException.class, () -> service.readAttributes(file, "nonexistview:*"));
+  }
+
+  @Test
   public void testIllegalAttributeFormats() {
     File file = createFile();
     IllegalArgumentException expected =


### PR DESCRIPTION
## Summary
- `Files#readAttributes` with a nonexistent attribute view (e.g. `"nonexistview:*"`) threw `NullPointerException` instead of the `UnsupportedOperationException` required by the API.
- Validate the view name up front in `AttributeService#readAttributes` and add a focused regression test.

Fixes #212

## Test plan
- [x] `mvn -pl jimfs test -Dtest=AttributeServiceTest#testReadAttributes_failsForUnsupportedAttributeView`
- [x] `mvn -pl jimfs test`


Made with [Cursor](https://cursor.com)