### PR TITLE
Fix WatchService modification detection with fixed timestamps

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/File.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/File.java
@@ -42,7 +42,7 @@ public abstract class File {
   private FileTime creationTime;
   private FileTime lastAccessTime;
   private FileTime lastModifiedTime;
-  private long modificationCount;
+  private long modificationVersion;
 
   // null when only the basic view is used (default)
   private @Nullable Table<String, String, Object> attributes;
@@ -169,9 +169,9 @@ public abstract class File {
     return lastModifiedTime;
   }
 
-  /** Returns the number of times this file has been modified. */
-  final synchronized long getModificationCount() {
-    return modificationCount;
+  /** Returns the current modification version of this file. */
+  final synchronized long getModificationVersion() {
+    return modificationVersion;
   }
 
   /** Sets the creation time of the file. */
@@ -187,7 +187,7 @@ public abstract class File {
   /** Sets the last modified time of the file. */
   final synchronized void setLastModifiedTime(FileTime lastModifiedTime) {
     this.lastModifiedTime = lastModifiedTime;
-    modificationCount++;
+    modificationVersion++;
   }
 
   /**

--- a/jimfs/src/main/java/com/google/common/jimfs/File.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/File.java
@@ -42,6 +42,7 @@ public abstract class File {
   private FileTime creationTime;
   private FileTime lastAccessTime;
   private FileTime lastModifiedTime;
+  private long modificationCount;
 
   // null when only the basic view is used (default)
   private @Nullable Table<String, String, Object> attributes;
@@ -168,6 +169,11 @@ public abstract class File {
     return lastModifiedTime;
   }
 
+  /** Returns the number of times this file has been modified. */
+  final synchronized long getModificationCount() {
+    return modificationCount;
+  }
+
   /** Sets the creation time of the file. */
   final synchronized void setCreationTime(FileTime creationTime) {
     this.creationTime = creationTime;
@@ -181,6 +187,7 @@ public abstract class File {
   /** Sets the last modified time of the file. */
   final synchronized void setLastModifiedTime(FileTime lastModifiedTime) {
     this.lastModifiedTime = lastModifiedTime;
+    modificationCount++;
   }
 
   /**

--- a/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
@@ -176,25 +176,25 @@ final class FileSystemView {
   static final class EntryState {
 
     private final int fileId;
-    private final long modificationCount;
+    private final long modificationVersion;
 
     EntryState(File file) {
       this.fileId = file.id();
-      this.modificationCount = file.getModificationCount();
+      this.modificationVersion = file.getModificationVersion();
     }
 
     @Override
     public boolean equals(@Nullable Object obj) {
       if (obj instanceof EntryState) {
         EntryState other = (EntryState) obj;
-        return fileId == other.fileId && modificationCount == other.modificationCount;
+        return fileId == other.fileId && modificationVersion == other.modificationVersion;
       }
       return false;
     }
 
     @Override
     public int hashCode() {
-      return 31 * fileId + Long.hashCode(modificationCount);
+      return 31 * fileId + Long.hashCode(modificationVersion);
     }
   }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java
@@ -149,12 +149,9 @@ final class FileSystemView {
     }
   }
 
-  /**
-   * Returns a snapshot mapping the names of each file in the directory at the given path to the
-   * last modified time of that file.
-   */
-  public ImmutableMap<Name, FileTime> snapshotModifiedTimes(JimfsPath path) throws IOException {
-    ImmutableMap.Builder<Name, FileTime> modifiedTimes = ImmutableMap.builder();
+  /** Returns a snapshot mapping each entry in the given directory to its current state. */
+  public ImmutableMap<Name, EntryState> snapshotEntryStates(JimfsPath path) throws IOException {
+    ImmutableMap.Builder<Name, EntryState> entryStates = ImmutableMap.builder();
 
     store.readLock().lock();
     try {
@@ -165,13 +162,39 @@ final class FileSystemView {
 
       for (DirectoryEntry entry : dir) {
         if (!entry.name().equals(Name.SELF) && !entry.name().equals(Name.PARENT)) {
-          modifiedTimes.put(entry.name(), entry.file().getLastModifiedTime());
+          entryStates.put(entry.name(), new EntryState(entry.file()));
         }
       }
 
-      return modifiedTimes.build();
+      return entryStates.build();
     } finally {
       store.readLock().unlock();
+    }
+  }
+
+  /** State used to determine whether an entry changed between directory snapshots. */
+  static final class EntryState {
+
+    private final int fileId;
+    private final long modificationCount;
+
+    EntryState(File file) {
+      this.fileId = file.id();
+      this.modificationCount = file.getModificationCount();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+      if (obj instanceof EntryState) {
+        EntryState other = (EntryState) obj;
+        return fileId == other.fileId && modificationCount == other.modificationCount;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * fileId + Long.hashCode(modificationCount);
     }
   }
 

--- a/jimfs/src/main/java/com/google/common/jimfs/PollingWatchService.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/PollingWatchService.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchService;
 import java.nio.file.Watchable;
-import java.nio.file.attribute.FileTime;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -194,17 +193,17 @@ final class PollingWatchService extends AbstractWatchService {
       };
 
   private Snapshot takeSnapshot(JimfsPath path) throws IOException {
-    return new Snapshot(view.snapshotModifiedTimes(path));
+    return new Snapshot(view.snapshotEntryStates(path));
   }
 
   /** Snapshot of the state of a directory at a particular moment. */
   private final class Snapshot {
 
-    /** Maps directory entry names to last modified times. */
-    private final ImmutableMap<Name, FileTime> modifiedTimes;
+    /** Maps directory entry names to their state at the time of the snapshot. */
+    private final ImmutableMap<Name, FileSystemView.EntryState> entryStates;
 
-    Snapshot(Map<Name, FileTime> modifiedTimes) {
-      this.modifiedTimes = ImmutableMap.copyOf(modifiedTimes);
+    Snapshot(Map<Name, FileSystemView.EntryState> entryStates) {
+      this.entryStates = ImmutableMap.copyOf(entryStates);
     }
 
     /**
@@ -216,7 +215,7 @@ final class PollingWatchService extends AbstractWatchService {
 
       if (key.subscribesTo(ENTRY_CREATE)) {
         Set<Name> created =
-            Sets.difference(newState.modifiedTimes.keySet(), modifiedTimes.keySet());
+            Sets.difference(newState.entryStates.keySet(), entryStates.keySet());
 
         for (Name name : created) {
           key.post(new Event<>(ENTRY_CREATE, 1, pathService.createFileName(name)));
@@ -226,7 +225,7 @@ final class PollingWatchService extends AbstractWatchService {
 
       if (key.subscribesTo(ENTRY_DELETE)) {
         Set<Name> deleted =
-            Sets.difference(modifiedTimes.keySet(), newState.modifiedTimes.keySet());
+            Sets.difference(entryStates.keySet(), newState.entryStates.keySet());
 
         for (Name name : deleted) {
           key.post(new Event<>(ENTRY_DELETE, 1, pathService.createFileName(name)));
@@ -235,12 +234,12 @@ final class PollingWatchService extends AbstractWatchService {
       }
 
       if (key.subscribesTo(ENTRY_MODIFY)) {
-        for (Map.Entry<Name, FileTime> entry : modifiedTimes.entrySet()) {
+        for (Map.Entry<Name, FileSystemView.EntryState> entry : entryStates.entrySet()) {
           Name name = entry.getKey();
-          FileTime modifiedTime = entry.getValue();
+          FileSystemView.EntryState state = entry.getValue();
 
-          FileTime newModifiedTime = newState.modifiedTimes.get(name);
-          if (newModifiedTime != null && !modifiedTime.equals(newModifiedTime)) {
+          FileSystemView.EntryState newEntryState = newState.entryStates.get(name);
+          if (newEntryState != null && !state.equals(newEntryState)) {
             key.post(new Event<>(ENTRY_MODIFY, 1, pathService.createFileName(name)));
             changesPosted = true;
           }

--- a/jimfs/src/test/java/com/google/common/jimfs/PollingWatchServiceTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/PollingWatchServiceTest.java
@@ -29,12 +29,14 @@ import com.google.common.jimfs.AbstractWatchService.Key;
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
+import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -210,6 +212,38 @@ public class PollingWatchServiceTest {
         ImmutableList.<WatchEvent<?>>of(
             new Event<>(ENTRY_MODIFY, 1, fs.getPath("foo")),
             new Event<>(ENTRY_DELETE, 1, fs.getPath("foo"))));
+  }
+
+  @Test(timeout = 2000)
+  public void testWatchForModificationWhenModifiedTimeDoesNotChange()
+      throws IOException, InterruptedException {
+    watcher.close();
+    fs.close();
+
+    FileTime fixedTime = FileTime.fromMillis(0);
+    fs =
+        (JimfsFileSystem)
+            Jimfs.newFileSystem(
+                Configuration.unix()
+                    .toBuilder()
+                    .setFileTimeSource(() -> fixedTime)
+                    .build());
+    watcher =
+        new PollingWatchService(
+            fs.getDefaultView(),
+            fs.getPathService(),
+            new FileSystemState(new FakeFileTimeSource(), Runnables.doNothing()),
+            4,
+            MILLISECONDS);
+
+    JimfsPath path = createDirectory();
+    Path file = Files.write(path.resolve("foo"), "before".getBytes(StandardCharsets.UTF_8));
+    watcher.register(path, ImmutableList.of(ENTRY_MODIFY));
+
+    Files.write(file, "after".getBytes(StandardCharsets.UTF_8));
+
+    assertThat(Files.getLastModifiedTime(file)).isEqualTo(fixedTime);
+    assertWatcherHasEvents(new Event<>(ENTRY_MODIFY, 1, fs.getPath("foo")));
   }
 
   private void assertWatcherHasEvents(WatchEvent<?>... events) throws InterruptedException {


### PR DESCRIPTION
## Summary

- track a monotonic modification version for each in-memory file
- compare file identity and modification version in polling directory snapshots
- add a regression test using a fixed `FileTimeSource`

## Problem

`PollingWatchService` currently compares only `lastModifiedTime` values. If a file is written while the configured clock returns the same timestamp (for example, a fixed or low-resolution clock), the content changes but no `ENTRY_MODIFY` event is emitted.

The new snapshot state uses the file ID and its modification version. This detects writes without reading or hashing file contents, while also distinguishing a same-name replacement file.

## Testing

- `mvn -pl jimfs -Dtest=PollingWatchServiceTest,FileTest test`
- `mvn test` (5,906 tests passed, 1 skipped)

Fixes #483
