### PR TITLE
Return configured block size from FileStore.getBlockSize()

### DIFF
--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
@@ -240,13 +240,6 @@ final class JimfsFileStore extends FileStore {
     return disk.getUnallocatedSpace();
   }
 
-  /**
-   * Returns the configured block size for this file store.
-   *
-   * <p>{@code FileStore.getBlockSize()} exists from Java 10 onward. This method is intentionally
-   * not annotated with {@code @Override} so Jimfs still compiles against Java 8; on Java 10+ it
-   * overrides the JDK method at runtime.
-   */
   @SuppressWarnings("MissingOverride") // FileStore.getBlockSize() is Java 10+
   public long getBlockSize() throws IOException {
     state.checkOpen();

--- a/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
+++ b/jimfs/src/main/java/com/google/common/jimfs/JimfsFileStore.java
@@ -240,6 +240,19 @@ final class JimfsFileStore extends FileStore {
     return disk.getUnallocatedSpace();
   }
 
+  /**
+   * Returns the configured block size for this file store.
+   *
+   * <p>{@code FileStore.getBlockSize()} exists from Java 10 onward. This method is intentionally
+   * not annotated with {@code @Override} so Jimfs still compiles against Java 8; on Java 10+ it
+   * overrides the JDK method at runtime.
+   */
+  @SuppressWarnings("MissingOverride") // FileStore.getBlockSize() is Java 10+
+  public long getBlockSize() throws IOException {
+    state.checkOpen();
+    return disk.blockSize();
+  }
+
   @Override
   public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
     state.checkOpen();

--- a/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
@@ -39,7 +38,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.PosixFilePermissions;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -252,29 +250,6 @@ public class ConfigurationTest {
 
     FileStore store = Files.getFileStore(path);
     assertThat(((JimfsFileStore) store).getBlockSize()).isEqualTo(blockSize);
-    assertThat(invokeFileStoreGetBlockSize(store)).isEqualTo(blockSize);
-  }
-
-  /**
-   * Invokes {@code FileStore.getBlockSize()} reflectively. That method was added in Java 10; on
-   * Java 8 the test is skipped rather than failing to compile.
-   */
-  private static long invokeFileStoreGetBlockSize(FileStore store) throws Exception {
-    try {
-      return (Long) FileStore.class.getMethod("getBlockSize").invoke(store);
-    } catch (NoSuchMethodException e) {
-      Assume.assumeTrue("FileStore.getBlockSize() requires Java 10+", false);
-      throw new AssertionError(e);
-    } catch (InvocationTargetException e) {
-      Throwable cause = e.getCause();
-      if (cause instanceof Exception) {
-        throw (Exception) cause;
-      }
-      if (cause instanceof Error) {
-        throw (Error) cause;
-      }
-      throw e;
-    }
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
@@ -31,12 +31,15 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.PosixFilePermissions;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -228,12 +231,50 @@ public class ConfigurationTest {
     assertThat(fs.supportedFileAttributeViews()).containsExactly("basic", "owner", "posix", "unix");
 
     Files.createFile(fs.getPath("/foo"));
+    assertThat(((JimfsFileStore) Iterables.getOnlyElement(fs.getFileStores())).getBlockSize())
+        .isEqualTo(10);
     assertThat(Files.getAttribute(fs.getPath("/foo"), "posix:permissions"))
         .isEqualTo(PosixFilePermissions.fromString("---------"));
     assertThat(Files.getAttribute(fs.getPath("/foo"), "creationTime"))
         .isEqualTo(fileTimeSource.now());
 
     assertThrows(FileAlreadyExistsException.class, () -> Files.createFile(fs.getPath("/FOO")));
+  }
+
+  @Test
+  public void testFileStoreGetBlockSizeHonorsConfiguration() throws Exception {
+    int blockSize = 1 << 12;
+    Configuration configuration = Configuration.unix().toBuilder().setBlockSize(blockSize).build();
+    FileSystem fs = Jimfs.newFileSystem(configuration);
+    Path path = fs.getPath("/home/test/test.txt");
+    Files.createDirectories(path.getParent());
+    Files.createFile(path);
+
+    FileStore store = Files.getFileStore(path);
+    assertThat(((JimfsFileStore) store).getBlockSize()).isEqualTo(blockSize);
+    assertThat(invokeFileStoreGetBlockSize(store)).isEqualTo(blockSize);
+  }
+
+  /**
+   * Invokes {@code FileStore.getBlockSize()} reflectively. That method was added in Java 10; on
+   * Java 8 the test is skipped rather than failing to compile.
+   */
+  private static long invokeFileStoreGetBlockSize(FileStore store) throws Exception {
+    try {
+      return (Long) FileStore.class.getMethod("getBlockSize").invoke(store);
+    } catch (NoSuchMethodException e) {
+      Assume.assumeTrue("FileStore.getBlockSize() requires Java 10+", false);
+      throw new AssertionError(e);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw e;
+    }
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/ConfigurationTest.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -237,19 +236,6 @@ public class ConfigurationTest {
         .isEqualTo(fileTimeSource.now());
 
     assertThrows(FileAlreadyExistsException.class, () -> Files.createFile(fs.getPath("/FOO")));
-  }
-
-  @Test
-  public void testFileStoreGetBlockSizeHonorsConfiguration() throws Exception {
-    int blockSize = 1 << 12;
-    Configuration configuration = Configuration.unix().toBuilder().setBlockSize(blockSize).build();
-    FileSystem fs = Jimfs.newFileSystem(configuration);
-    Path path = fs.getPath("/home/test/test.txt");
-    Files.createDirectories(path.getParent());
-    Files.createFile(path);
-
-    FileStore store = Files.getFileStore(path);
-    assertThat(((JimfsFileStore) store).getBlockSize()).isEqualTo(blockSize);
   }
 
   @Test

--- a/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
+++ b/jimfs/src/test/java/com/google/common/jimfs/JimfsUnixLikeFileSystemTest.java
@@ -142,6 +142,9 @@ public class JimfsUnixLikeFileSystemTest extends AbstractJimfsIntegrationTest {
 
     long totalSpace = 1024 * 1024 * 1024; // 1 GB
     assertThat(fileStore.getTotalSpace()).isEqualTo(totalSpace);
+    // Default unix block size; FileStore.getBlockSize() is Java 10+, so call the Jimfs method
+    // directly (same package) so this still compiles on Java 8.
+    assertThat(((JimfsFileStore) fileStore).getBlockSize()).isEqualTo(8192);
     assertThat(fileStore.getUnallocatedSpace()).isEqualTo(totalSpace);
     assertThat(fileStore.getUsableSpace()).isEqualTo(totalSpace);
 


### PR DESCRIPTION
`FileStore.getBlockSize()` was added in Java 10. Jimfs already keeps the configured size on `HeapDisk` (`Configuration.setBlockSize`), but `JimfsFileStore` never overrode the JDK method, so callers always got `UnsupportedOperationException`.

This implements `getBlockSize()` by returning `disk.blockSize()`. There is no `@Override` so the project still compiles on Java 8; on 10+ it overrides at runtime.

Fixes #183

The new test matches the repro from the issue (unix config, `setBlockSize(1 << 12)`). Direct calls go through `JimfsFileStore.getBlockSize()` so they compile on 8; a reflective call covers `FileStore.getBlockSize()` on 10+ and is skipped on 8.